### PR TITLE
Expecting parser errors and avoid multiple 'p' in hex-float

### DIFF
--- a/packages/wast-parser/src/tokenizer.js
+++ b/packages/wast-parser/src/tokenizer.js
@@ -268,6 +268,10 @@ function tokenize(input: string) {
         numberLiterals.test(char) ||
         (input[current - 1] === "p" && char === "+")
       ) {
+        if (char === "p" && value.includes("p")) {
+          throw new Error("Unexpected character `p`.");
+        }
+
         if (char !== "_") {
           value += char;
         }

--- a/packages/wast-parser/test/fixtures/number-literals/invalid/hex-float-pp/actual.wast
+++ b/packages/wast-parser/test/fixtures/number-literals/invalid/hex-float-pp/actual.wast
@@ -1,0 +1,4 @@
+(func
+  (f32.const 0x123pp-3)
+)
+

--- a/packages/wast-parser/test/fixtures/number-literals/invalid/hex-float-pp/throws.txt
+++ b/packages/wast-parser/test/fixtures/number-literals/invalid/hex-float-pp/throws.txt
@@ -1,0 +1,2 @@
+Unexpected character `p`.
+


### PR DESCRIPTION
Hi! I will try to incrementally improve the `wast-parser` package. This PR does two things:

* Adds support for `throws.txt` file instead of `expected.json` for test cases where a parser error is expected. The file should contain the expected error message.

* Makes sure that multiple `p` in a floating point hexadecimal literal are not parsed, but throw an error instead.