### PR TITLE
Create wasm-strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See [WebAssembly.js.org](https://webassembly.js.org) for more information.
 - [wasm-parser](https://github.com/xtuc/webassemblyjs/tree/master/packages/wasm-parser) - WebAssembly binary format parser
 - [wast-parser](https://github.com/xtuc/webassemblyjs/tree/master/packages/wast-parser) - WebAssembly text format parser
 - [wast-printer](https://github.com/xtuc/webassemblyjs/tree/master/packages/wast-printer) - WebAssembly text format printer
+- [wast-strip](https://github.com/xtuc/webassemblyjs/tree/master/packages/wast-strip) - Strips custom sections
 - [webassemblyjs](https://github.com/xtuc/webassemblyjs/tree/master/packages/webassemblyjs) - WebAssembly interpreter, implements the W3C WebAssembly API.
 
 

--- a/packages/wasm-strip/README.md
+++ b/packages/wasm-strip/README.md
@@ -1,0 +1,15 @@
+# @webassemblyjs/wasm-strip
+
+> Strips custom sections
+
+## Installation
+
+```sh
+npm install -g @webassemblyjs/wasm-strip
+```
+
+## Usage
+
+```sh
+wasm-strip FILENAME
+```

--- a/packages/wasm-strip/package.json
+++ b/packages/wasm-strip/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@webassemblyjs/wasm-strip",
+  "version": "1.2.1",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xtuc/webassemblyjs.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Sven Sauleau",
+  "license": "GPL-2.0",
+  "bin": {
+    "wasm-strip": "./lib/cli.js"
+  },
+  "dependencies": {
+    "@webassemblyjs/wasm-parser": "1.2.1",
+    "@webassemblyjs/helper-wasm-section": "1.2.1"
+  }
+}

--- a/packages/wasm-strip/src/cli.js
+++ b/packages/wasm-strip/src/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const { readFileSync, writeFileSync } = require("fs");
+
+const strip = require("./").default;
+
+const filename = process.argv[2];
+
+if (typeof filename === "undefined") {
+  throw new Error("Missing file");
+}
+
+const bin = readFileSync(filename, null);
+
+const newBin = strip(bin);
+
+writeFileSync(filename, new Buffer(newBin));

--- a/packages/wasm-strip/src/index.js
+++ b/packages/wasm-strip/src/index.js
@@ -1,0 +1,19 @@
+// @flow
+
+import { decode } from "@webassemblyjs/wasm-parser";
+import { removeSection } from "@webassemblyjs/helper-wasm-section";
+
+const decoderOpts = {
+  ignoreCodeSection: true,
+  ignoreDataSection: true
+};
+
+export default function strip(bin: ArrayBuffer): ArrayBuffer {
+  const ast = decode(bin, decoderOpts);
+
+  let uint8Buffer = new Uint8Array(bin);
+
+  uint8Buffer = removeSection(ast, uint8Buffer, "custom");
+
+  return uint8Buffer.buffer;
+}


### PR DESCRIPTION
Strips out the custom sections.

Currently only support one section, which works the binary emitted by wabt (wat2wasm).