### PR TITLE
fix: make watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 	./scripts/build.sh
 
 watch:
-	$(BABEL) --out-dir lib/ src/ --watch
+	./scripts/build.sh --watch
 
 test-ci: test test-whitelisted-spec lint
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,18 +4,14 @@ set -e
 ROOT_DIR=$(cd $(dirname $0)/..; pwd)
 cd $ROOT_DIR
 
-PACKAGE="$1"
+OPTS="$@"
 
 for D in ./packages/*; do
   if [ ! -d "${D}/src" ]; then
     continue
   fi
 
-  if [ -n "$PACKAGE" ] && [ `basename $D` != "$PACKAGE" ]; then
-    continue
-  fi
-
-  echo "Building $D..."
+  echo "Building $D $OPTS..."
 
   # Clean
   rm -rf "${D}/lib"
@@ -23,7 +19,10 @@ for D in ./packages/*; do
   # Build
   ./node_modules/.bin/babel "${D}/src" \
     --out-dir "${D}/lib" \
-    --ignore packages/dce/src/libwabt.js
+    --ignore packages/dce/src/libwabt.js \
+    $OPTS &
 done
+
+wait
 
 cp -v packages/dce/src/libwabt.js packages/dce/lib/libwabt.js


### PR DESCRIPTION
Now every package is build is a separated process (which allows to watch every package at the same time).

I suspect the Node startup to make it actually slower (Δ + ~2sec.). 