### PR TITLE
Implement lookhead() and lookback() as functions [->lookbehind()]

### DIFF
--- a/packages/wast-parser/src/tokenizer.js
+++ b/packages/wast-parser/src/tokenizer.js
@@ -115,13 +115,13 @@ function tokenize(input: string) {
   /**
    * Can be used to look at the next character(s).
    *
-   * The default behavior `peek()` simply returns the next character without consuming it.
+   * The default behavior `lookahead()` simply returns the next character without consuming it.
    *
    * @param int length How many characters to query. Default = 1
    * @param int offset How many characters to skip from current one. Default = 1
    *
    */
-  function peek(length = 1, offset = 1) {
+  function lookahead(length = 1, offset = 1) {
     return input.substring(current + offset, current + offset + length);
   }
 
@@ -134,7 +134,7 @@ function tokenize(input: string) {
     let char = input[current];
 
     // ;;
-    if (char === ";" && peek() === ";") {
+    if (char === ";" && lookahead() === ";") {
       eatToken();
       eatToken();
 
@@ -160,7 +160,7 @@ function tokenize(input: string) {
     }
 
     // (;
-    if (char === "(" && peek() === ";") {
+    if (char === "(" && lookahead() === ";") {
       eatToken(); // (
       eatToken(); // ;
 
@@ -172,7 +172,7 @@ function tokenize(input: string) {
       while (true) {
         char = input[current];
 
-        if (char === ";" && peek() === ")") {
+        if (char === ";" && lookahead() === ")") {
           eatToken(); // ;
           eatToken(); // )
 
@@ -249,7 +249,7 @@ function tokenize(input: string) {
 
     if (
       NUMBERS.test(char) ||
-      NUMBER_KEYWORDS.test(peek(3, 0)) ||
+      NUMBER_KEYWORDS.test(lookahead(3, 0)) ||
       char === "-"
     ) {
       let value = "";
@@ -258,11 +258,11 @@ function tokenize(input: string) {
         char = input[++current];
       }
 
-      if (NUMBER_KEYWORDS.test(peek(3, 0))) {
+      if (NUMBER_KEYWORDS.test(lookahead(3, 0))) {
         let tokenLength = 3;
-        if (peek(4, 0) === "nan:") {
+        if (lookahead(4, 0) === "nan:") {
           tokenLength = 4;
-        } else if (peek(3, 0) === "nan") {
+        } else if (lookahead(3, 0) === "nan") {
           tokenLength = 3;
         }
         value += input.substring(current, current + tokenLength);
@@ -271,7 +271,7 @@ function tokenize(input: string) {
 
       let numberLiterals = NUMBERS;
 
-      if (char === "0" && peek().toUpperCase() === "X") {
+      if (char === "0" && lookahead().toUpperCase() === "X") {
         value += "0x";
         numberLiterals = HEX_NUMBERS;
         char = input[(current += 2)];

--- a/packages/wast-parser/src/tokenizer.js
+++ b/packages/wast-parser/src/tokenizer.js
@@ -122,7 +122,7 @@ function tokenize(input: string) {
    *
    */
   function peek(length = 1, offset = 1) {
-    return input.substring(current + offset,current + offset + length);
+    return input.substring(current + offset, current + offset + length);
   }
 
   function eatToken() {
@@ -249,7 +249,7 @@ function tokenize(input: string) {
 
     if (
       NUMBERS.test(char) ||
-      NUMBER_KEYWORDS.test(peek(3,0)) ||
+      NUMBER_KEYWORDS.test(peek(3, 0)) ||
       char === "-"
     ) {
       let value = "";
@@ -258,11 +258,11 @@ function tokenize(input: string) {
         char = input[++current];
       }
 
-      if (NUMBER_KEYWORDS.test(peek(3,0))) {
+      if (NUMBER_KEYWORDS.test(peek(3, 0))) {
         let tokenLength = 3;
-        if (peek(4,0) === "nan:") {
+        if (peek(4, 0) === "nan:") {
           tokenLength = 4;
-        } else if (peek(3,0) === "nan") {
+        } else if (peek(3, 0) === "nan") {
           tokenLength = 3;
         }
         value += input.substring(current, current + tokenLength);

--- a/packages/wast-parser/src/tokenizer.js
+++ b/packages/wast-parser/src/tokenizer.js
@@ -118,11 +118,24 @@ function tokenize(input: string) {
    * The default behavior `lookahead()` simply returns the next character without consuming it.
    *
    * @param int length How many characters to query. Default = 1
-   * @param int offset How many characters to skip from current one. Default = 1
+   * @param int offset How many characters to skip forward from current one. Default = 1
    *
    */
   function lookahead(length = 1, offset = 1) {
     return input.substring(current + offset, current + offset + length);
+  }
+
+  /**
+   * Can be used to look at the last few character(s).
+   *
+   * The default behavior `lookback()` simply returns the last character.
+   *
+   * @param int length How many characters to query. Default = 1
+   * @param int offset How many characters to skip back from current one. Default = 1
+   *
+   */
+  function lookback(length = 1, offset = 1) {
+    return input.substring(current - offset, current - offset + length);
   }
 
   function eatToken() {
@@ -279,8 +292,8 @@ function tokenize(input: string) {
 
       while (
         numberLiterals.test(char) ||
-        (input[current - 1] === "p" && char === "+") ||
-        (input[current - 1].toUpperCase() === "E" && char === "-") ||
+        (lookback() === "p" && char === "+") ||
+        (lookback().toUpperCase() === "E" && char === "-") ||
         (value.length > 0 && char.toUpperCase() === "E")
       ) {
         if (char === "p" && value.includes("p")) {

--- a/packages/wast-parser/src/tokenizer.js
+++ b/packages/wast-parser/src/tokenizer.js
@@ -128,13 +128,13 @@ function tokenize(input: string) {
   /**
    * Can be used to look at the last few character(s).
    *
-   * The default behavior `lookback()` simply returns the last character.
+   * The default behavior `lookbehind()` simply returns the last character.
    *
    * @param int length How many characters to query. Default = 1
    * @param int offset How many characters to skip back from current one. Default = 1
    *
    */
-  function lookback(length = 1, offset = 1) {
+  function lookbehind(length = 1, offset = 1) {
     return input.substring(current - offset, current - offset + length);
   }
 
@@ -292,8 +292,8 @@ function tokenize(input: string) {
 
       while (
         numberLiterals.test(char) ||
-        (lookback() === "p" && char === "+") ||
-        (lookback().toUpperCase() === "E" && char === "-") ||
+        (lookbehind() === "p" && char === "+") ||
+        (lookbehind().toUpperCase() === "E" && char === "-") ||
         (value.length > 0 && char.toUpperCase() === "E")
       ) {
         if (char === "p" && value.includes("p")) {

--- a/packages/wast-parser/src/tokenizer.js
+++ b/packages/wast-parser/src/tokenizer.js
@@ -112,6 +112,19 @@ function tokenize(input: string) {
 
   const tokens = [];
 
+  /**
+   * Can be used to look at the next character(s).
+   *
+   * The default behavior `peek()` simply returns the next character without consuming it.
+   *
+   * @param int length How many characters to query. Default = 1
+   * @param int offset How many characters to skip from current one. Default = 1
+   *
+   */
+  function peek(length = 1, offset = 1) {
+    return input.substring(current + offset,current + offset + length);
+  }
+
   function eatToken() {
     column++;
     current++;
@@ -121,7 +134,7 @@ function tokenize(input: string) {
     let char = input[current];
 
     // ;;
-    if (char === ";" && input[current + 1] === ";") {
+    if (char === ";" && peek() === ";") {
       eatToken();
       eatToken();
 
@@ -147,7 +160,7 @@ function tokenize(input: string) {
     }
 
     // (;
-    if (char === "(" && input[current + 1] === ";") {
+    if (char === "(" && peek() === ";") {
       eatToken(); // (
       eatToken(); // ;
 
@@ -159,7 +172,7 @@ function tokenize(input: string) {
       while (true) {
         char = input[current];
 
-        if (char === ";" && input[current + 1] === ")") {
+        if (char === ";" && peek() === ")") {
           eatToken(); // ;
           eatToken(); // )
 
@@ -236,7 +249,7 @@ function tokenize(input: string) {
 
     if (
       NUMBERS.test(char) ||
-      NUMBER_KEYWORDS.test(input.substring(current, current + 3)) ||
+      NUMBER_KEYWORDS.test(peek(3,0)) ||
       char === "-"
     ) {
       let value = "";
@@ -245,11 +258,11 @@ function tokenize(input: string) {
         char = input[++current];
       }
 
-      if (NUMBER_KEYWORDS.test(input.substring(current, current + 3))) {
+      if (NUMBER_KEYWORDS.test(peek(3,0))) {
         let tokenLength = 3;
-        if (input.substring(current, current + 4) === "nan:") {
+        if (peek(4,0) === "nan:") {
           tokenLength = 4;
-        } else if (input.substring(current, current + 3) === "nan") {
+        } else if (peek(3,0) === "nan") {
           tokenLength = 3;
         }
         value += input.substring(current, current + tokenLength);
@@ -258,7 +271,7 @@ function tokenize(input: string) {
 
       let numberLiterals = NUMBERS;
 
-      if (char === "0" && input[current + 1].toUpperCase() === "X") {
+      if (char === "0" && peek().toUpperCase() === "X") {
         value += "0x";
         numberLiterals = HEX_NUMBERS;
         char = input[(current += 2)];


### PR DESCRIPTION
This introduces two helper functions `lookahead()` and `lookback()` to look at input characters without consuming them. It builds on #205 

What do you think of this direction in general? There is a lot of fiddling with the `current` pointer and direct references to `input` that it is sometimes hard to tell whats going on. I'd like to convert most of these operations into small utility functions in order to make the "main" code more readable.

@xtuc Did you avoid helper functions on purpose or is this something that makes sense to you? In C I would make these helper functions macros to make sure there is no overhead, which would technically be possible here too with `babel-macros`. But I'd rather avoid that if possible.