### PR TITLE
Additional validation from the wat parser

### DIFF
--- a/packages/ast/src/traverse.js
+++ b/packages/ast/src/traverse.js
@@ -71,8 +71,13 @@ function walk(n: Node, cb: Cb, parentPath: ?NodePath<Node>) {
     case "Data":
     case "Memory":
     case "Elem":
+    case "FuncImportDescr":
+    case "GlobalType":
     case "NumberLiteral":
+    case "ValtypeLiteral":
     case "FloatLiteral":
+    case "StringLiteral":
+    case "QuoteModule":
     case "LongNumberLiteral":
     case "BinaryModule":
     case "LeadingComment":
@@ -127,7 +132,10 @@ function walk(n: Node, cb: Cb, parentPath: ?NodePath<Node>) {
     case "ModuleImport": {
       cb(n.type, createPath(n, parentPath));
 
-      cb(n.descr.type, createPath(n.descr, parentPath));
+      if (n.descr != null) {
+        // $FlowIgnore
+        walk(n.descr, cb, createPath(n, parentPath));
+      }
 
       break;
     }
@@ -139,6 +147,11 @@ function walk(n: Node, cb: Cb, parentPath: ?NodePath<Node>) {
 
       if (n.name != null) {
         walk(n.name, cb, path);
+      }
+
+      if (n.init != null) {
+        // $FlowIgnore
+        n.init.forEach(x => walk(x, cb, path));
       }
 
       break;

--- a/packages/wasm-edit/test/replace-node.js
+++ b/packages/wasm-edit/test/replace-node.js
@@ -95,8 +95,10 @@ describe("replace a node", () => {
 
     const newBinary = edit(actualBinary, {
       Instr(path) {
-        const newNode = t.callInstruction(t.indexLiteral(0));
-        path.replaceWith(newNode);
+        if (path.node.id === "get_global") {
+          const newNode = t.callInstruction(t.indexLiteral(0));
+          path.replaceWith(newNode);
+        }
       }
     });
 
@@ -136,8 +138,10 @@ describe("replace a node", () => {
 
     const newBinary = edit(actualBinary, {
       Instr(path) {
-        const newNode = t.callIndirectInstructionIndex(t.indexLiteral(2));
-        path.replaceWith(newNode);
+        if (path.node.id === "get_global") {
+          const newNode = t.callIndirectInstructionIndex(t.indexLiteral(2));
+          path.replaceWith(newNode);
+        }
       }
     });
 

--- a/packages/wast-parser/src/grammar.js
+++ b/packages/wast-parser/src/grammar.js
@@ -40,11 +40,6 @@ type ParserState = {
     type: ExportDescr,
     name: string,
     id: Index
-  }>,
-  registredImportedElements: Array<{
-    module: string,
-    name: string,
-    descr: ImportDescr
   }>
 };
 
@@ -59,8 +54,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
   }
 
   const state: ParserState = {
-    registredExportedElements: [],
-    registredImportedElements: []
+    registredExportedElements: []
   };
 
   // But this time we're going to use recursion instead of a `while` loop. So we
@@ -854,16 +848,6 @@ export function parse(tokensList: Array<Object>, source: string): Program {
           state.registredExportedElements = [];
         }
 
-        if (state.registredImportedElements.length > 0) {
-          state.registredImportedElements.forEach(decl => {
-            moduleFields.push(
-              t.moduleImport(decl.module, decl.name, decl.descr)
-            );
-          });
-
-          state.registredImportedElements = [];
-        }
-
         token = tokensList[current];
       }
 
@@ -1442,16 +1426,16 @@ export function parse(tokensList: Array<Object>, source: string): Program {
         throw new TypeError("Could not determine global type");
       }
 
-      if (importing != null) {
-        importing.descr = type;
-
-        // $FlowIgnore: the type is correct but Flow doesn't like the mutation above
-        state.registredImportedElements.push(importing);
-      }
-
       maybeIgnoreComment();
 
       const init = [];
+
+      if (importing != null) {
+        importing.descr = type;
+        init.push(
+          t.moduleImport(importing.module, importing.name, importing.descr)
+        );
+      }
 
       /**
        * instr*

--- a/packages/wast-parser/test/fixtures/global/with-shorthand-import/actual.wast
+++ b/packages/wast-parser/test/fixtures/global/with-shorthand-import/actual.wast
@@ -1,7 +1,7 @@
 (module
-  (global $test (import "env" "a") i32 (i32.const 0))
-  (global (import "env" "b") i32 (i32.const 1))
-  (global (import "env" "c") (mut i32) (i32.const 1))
+  (global $test (import "env" "a") i32)
+  (global (import "env" "b") i32)
+  (global (import "env" "c") (mut i32))
 
   (global (import "m" "a") (mut i32))
 )

--- a/packages/wast-parser/test/fixtures/global/with-shorthand-import/expected.json
+++ b/packages/wast-parser/test/fixtures/global/with-shorthand-import/expected.json
@@ -14,16 +14,14 @@
           },
           "init": [
             {
-              "type": "Instr",
-              "id": "const",
-              "object": "i32",
-              "args": [
-                {
-                  "type": "NumberLiteral",
-                  "value": 0,
-                  "raw": "0"
-                }
-              ]
+              "type": "ModuleImport",
+              "module": "env",
+              "name": "a",
+              "descr": {
+                "type": "GlobalType",
+                "valtype": "i32",
+                "mutability": "const"
+              }
             }
           ],
           "name": {
@@ -32,16 +30,6 @@
           }
         },
         {
-          "type": "ModuleImport",
-          "module": "env",
-          "name": "a",
-          "descr": {
-            "type": "GlobalType",
-            "valtype": "i32",
-            "mutability": "const"
-          }
-        },
-        {
           "type": "Global",
           "globalType": {
             "type": "GlobalType",
@@ -50,16 +38,14 @@
           },
           "init": [
             {
-              "type": "Instr",
-              "id": "const",
-              "object": "i32",
-              "args": [
-                {
-                  "type": "NumberLiteral",
-                  "value": 1,
-                  "raw": "1"
-                }
-              ]
+              "type": "ModuleImport",
+              "module": "env",
+              "name": "b",
+              "descr": {
+                "type": "GlobalType",
+                "valtype": "i32",
+                "mutability": "const"
+              }
             }
           ],
           "name": {
@@ -68,13 +54,27 @@
           }
         },
         {
-          "type": "ModuleImport",
-          "module": "env",
-          "name": "b",
-          "descr": {
+          "type": "Global",
+          "globalType": {
             "type": "GlobalType",
             "valtype": "i32",
-            "mutability": "const"
+            "mutability": "var"
+          },
+          "init": [
+            {
+              "type": "ModuleImport",
+              "module": "env",
+              "name": "c",
+              "descr": {
+                "type": "GlobalType",
+                "valtype": "i32",
+                "mutability": "var"
+              }
+            }
+          ],
+          "name": {
+            "type": "Identifier",
+            "value": "global_3"
           }
         },
         {
@@ -86,54 +86,19 @@
           },
           "init": [
             {
-              "type": "Instr",
-              "id": "const",
-              "object": "i32",
-              "args": [
-                {
-                  "type": "NumberLiteral",
-                  "value": 1,
-                  "raw": "1"
-                }
-              ]
+              "type": "ModuleImport",
+              "module": "m",
+              "name": "a",
+              "descr": {
+                "type": "GlobalType",
+                "valtype": "i32",
+                "mutability": "var"
+              }
             }
           ],
           "name": {
             "type": "Identifier",
-            "value": "global_3"
-          }
-        },
-        {
-          "type": "ModuleImport",
-          "module": "env",
-          "name": "c",
-          "descr": {
-            "type": "GlobalType",
-            "valtype": "i32",
-            "mutability": "var"
-          }
-        },
-        {
-          "type": "Global",
-          "globalType": {
-            "type": "GlobalType",
-            "valtype": "i32",
-            "mutability": "var"
-          },
-          "init": [],
-          "name": {
-            "type": "Identifier",
             "value": "global_4"
-          }
-        },
-        {
-          "type": "ModuleImport",
-          "module": "m",
-          "name": "a",
-          "descr": {
-            "type": "GlobalType",
-            "valtype": "i32",
-            "mutability": "var"
           }
         }
       ]

--- a/packages/webassemblyjs/src/compiler/validation/import-order.js
+++ b/packages/webassemblyjs/src/compiler/validation/import-order.js
@@ -1,0 +1,51 @@
+// @flow
+
+import { traverse } from "@webassemblyjs/ast";
+
+// https://webassembly.github.io/spec/core/text/modules.html#text-module
+//
+// imports must appear before globals, memory, tables or functions. However, imports
+// may be embedded within other statetemnts, or statetemnts may be embedded within imports.
+// In these cases, the ordering rule is not applied
+export default function validate(ast: Program): Array<string> {
+  const errors = [];
+
+  function isImportInstruction(path) {
+    // various instructions can be embedded within an import statement. These
+    // are not subject to our order validation rule
+    return path.parentPath.node.type === "ModuleImport";
+  }
+
+  let noMoreImports = false;
+  traverse(ast, {
+    ModuleImport(path) {
+      if (noMoreImports && path.parentPath.node.type !== "Global") {
+        return errors.push(
+          "imports must occur before all non-import definitions"
+        );
+      }
+    },
+    Global(path) {
+      if (!isImportInstruction(path)) {
+        noMoreImports = true;
+      }
+    },
+    Memory(path) {
+      if (!isImportInstruction(path)) {
+        noMoreImports = true;
+      }
+    },
+    Table(path) {
+      if (!isImportInstruction(path)) {
+        noMoreImports = true;
+      }
+    },
+    Func(path) {
+      if (!isImportInstruction(path)) {
+        noMoreImports = true;
+      }
+    }
+  });
+
+  return errors;
+}

--- a/packages/webassemblyjs/src/compiler/validation/index.js
+++ b/packages/webassemblyjs/src/compiler/validation/index.js
@@ -2,12 +2,14 @@
 
 import funcResultTypeValidate from "./func-result-type";
 import mutGlobalValidate from "./mut-global";
+import importOrderValidate from "./import-order";
 
 export default function validateAST(ast: Program) {
   const errors = [];
 
   errors.push(...funcResultTypeValidate(ast));
   errors.push(...mutGlobalValidate(ast));
+  errors.push(...importOrderValidate(ast));
 
   if (errors.length !== 0) {
     const errorMessage = "Validation errors:\n" + errors.join("\n");

--- a/packages/webassemblyjs/test/fixtures/instantiate-data-section/global-offset/module.wast
+++ b/packages/webassemblyjs/test/fixtures/instantiate-data-section/global-offset/module.wast
@@ -1,6 +1,6 @@
 (module
-  (memory 20)
   (import "m" "a" (global i32))
+  (memory 20)
   ;; (global $a (import "m" "a") i32)
   (data 0 (get_global 0) "abc")
   (export "memory" (memory 0))

--- a/packages/webassemblyjs/test/index.js
+++ b/packages/webassemblyjs/test/index.js
@@ -15,7 +15,7 @@ function toArrayBuffer(buf) {
 describe("interpreter", () => {
   describe("wasm", () => {
     const testSuites = glob.sync(
-      "packages/WebAssembly/test/fixtures/**/module.wasm"
+      "packages/webassemblyjs/test/fixtures/**/module.wasm"
     );
 
     testSuites.forEach(suite => {
@@ -47,7 +47,7 @@ describe("interpreter", () => {
 
   describe("wat", () => {
     const testSuites = glob.sync(
-      "packages/WebAssembly/test/fixtures/**/module.wast"
+      "packages/webassemblyjs/test/fixtures/**/module.wast"
     );
 
     testSuites.forEach(suite => {


### PR DESCRIPTION
while running `wat2wasm` over various test cases I've spotted some rules that are not being applied. Currently there is validation logic within the interpreter, but not the wat-parser. As these rules seems to be enforced by `wat2wasm` I thought it was best to enforce them in the parser.

What do you think?

I've got a few other tests to fix as well, but thought it was worth getting some feedback.