### PR TITLE
Decode custom name section

### DIFF
--- a/packages/ast/src/index.js
+++ b/packages/ast/src/index.js
@@ -33,6 +33,32 @@ export function signature(object: string, name: string): SignatureMap {
   return sign[0];
 }
 
+export function functionNameMetadata(
+  value: string,
+  index: number
+): FunctionNameMetadata {
+  return {
+    type: "FunctionNameMetadata",
+    value,
+    index
+  };
+}
+
+export function moduleMetadata(
+  sections: Array<SectionMetadata>,
+  functionNames: Array<FunctionNameMetadata>
+): ModuleMetadata {
+  const n: ModuleMetadata = {
+    type: "ModuleMetadata",
+    sections
+  };
+
+  if (functionNames.length) {
+    n.functionNames = functionNames;
+  }
+  return n;
+}
+
 export function identifier(value: string): Identifier {
   return {
     type: "Identifier",

--- a/packages/ast/src/traverse.js
+++ b/packages/ast/src/traverse.js
@@ -67,6 +67,7 @@ function walk(n: Node, cb: Cb, parentPath: ?NodePath<Node>) {
     }
 
     case "SectionMetadata":
+    case "FunctionNameMetadata":
     case "ModuleExport":
     case "Data":
     case "Memory":
@@ -84,7 +85,18 @@ function walk(n: Node, cb: Cb, parentPath: ?NodePath<Node>) {
     case "BlockComment":
     case "Identifier": {
       cb(n.type, createPath(n, parentPath));
+      break;
+    }
 
+    case "ModuleMetadata": {
+      const path = createPath(n, parentPath);
+      cb(n.type, createPath(n, path));
+      n.sections.forEach(x => walk(x, cb, path));
+
+      if (typeof n.functionNames !== "undefined") {
+        // $FlowIgnore
+        n.functionNames.forEach(x => walk(x, cb, path));
+      }
       break;
     }
 
@@ -98,7 +110,7 @@ function walk(n: Node, cb: Cb, parentPath: ?NodePath<Node>) {
 
       if (typeof n.metadata !== "undefined") {
         // $FlowIgnore
-        n.metadata.sections.forEach(x => walk(x, cb, path));
+        walk(n.metadata, cb, path);
       }
 
       break;

--- a/packages/dce/test/fixtures/func/expected.wast
+++ b/packages/dce/test/fixtures/func/expected.wast
@@ -1,4 +1,4 @@
 (module 
   (type (func))
-  (func $func_1)
+  (func $func_0)
 )

--- a/packages/dce/test/fixtures/referenced-func/expected.wast
+++ b/packages/dce/test/fixtures/referenced-func/expected.wast
@@ -1,10 +1,10 @@
 (module 
   (type (func))
-  (func $func_1
+  (func $referenceda
     (nop)
   )
   (func $func_2
     (call 0)
   )
-  (export "test" (func $func_1))
+  (export "test" (func $referenceda))
 )

--- a/packages/dce/test/fixtures/used-func-destructuring/expected.wast
+++ b/packages/dce/test/fixtures/used-func-destructuring/expected.wast
@@ -1,7 +1,7 @@
 (module 
   (type (func (param i32)))
-  (func $func_1 (param i32)
+  (func $foobar (param i32)
     (nop)
   )
-  (export "foobar" (func $func_1))
+  (export "foobar" (func $foobar))
 )

--- a/packages/dce/test/fixtures/used-func/expected.wast
+++ b/packages/dce/test/fixtures/used-func/expected.wast
@@ -1,7 +1,7 @@
 (module 
   (type (func (param i32)))
-  (func $func_1 (param i32)
+  (func $foobar (param i32)
     (nop)
   )
-  (export "foobar" (func $func_1))
+  (export "foobar" (func $foobar))
 )

--- a/packages/wasm-parser/src/index.js
+++ b/packages/wasm-parser/src/index.js
@@ -1,14 +1,51 @@
 // @flow
-
+import { traverse } from "@webassemblyjs/ast";
 import * as decoder from "./decoder";
 
 const defaultDecoderOpts = {
   dump: false,
   ignoreCodeSection: false,
-  ignoreDataSection: false
+  ignoreDataSection: false,
+  ignoreCustomNameSection: false
 };
+
+function restoreNames(ast) {
+  const functionNames = [];
+
+  traverse(ast, {
+    FunctionNameMetadata({ node }) {
+      functionNames.push({
+        name: node.value,
+        index: node.index
+      });
+    }
+  });
+
+  if (!functionNames.length) {
+    return;
+  }
+
+  traverse(ast, {
+    Func({ node }: NodePath<Func>) {
+      // $FlowIgnore
+      const nodeName: Identifier = node.name;
+      const indexBasedFunctionName = nodeName.value;
+      const index = Number(indexBasedFunctionName.replace("func_", ""));
+      const functionName = functionNames.find(f => f.index === index);
+      if (functionName) {
+        nodeName.value = functionName.name;
+      }
+    }
+  });
+}
 
 export function decode(buf: ArrayBuffer, customOpts: Object): Program {
   const opts: DecoderOpts = Object.assign({}, defaultDecoderOpts, customOpts);
-  return decoder.decode(buf, opts);
+  const ast = decoder.decode(buf, opts);
+
+  if (!opts.ignoreCustomNameSection) {
+    restoreNames(ast);
+  }
+
+  return ast;
 }

--- a/packages/wasm-parser/test/fixtures/basic/expected.json
+++ b/packages/wasm-parser/test/fixtures/basic/expected.json
@@ -35,7 +35,7 @@
           "type": "Func",
           "name": {
             "type": "Identifier",
-            "value": "func_1"
+            "value": "func_0"
           },
           "params": [
             {
@@ -116,7 +116,7 @@
           "type": "Func",
           "name": {
             "type": "Identifier",
-            "value": "func_2"
+            "value": "func_1"
           },
           "params": [
             {
@@ -200,7 +200,7 @@
             "type": "Func",
             "id": {
               "type": "Identifier",
-              "value": "func_1"
+              "value": "func_0"
             }
           },
           "loc": {
@@ -221,7 +221,7 @@
             "type": "Func",
             "id": {
               "type": "Identifier",
-              "value": "func_2"
+              "value": "func_1"
             }
           },
           "loc": {
@@ -237,6 +237,7 @@
         }
       ],
       "metadata": {
+        "type": "ModuleMetadata",
         "sections": [
           {
             "type": "SectionMetadata",

--- a/packages/wasm-parser/test/fixtures/section-metadata/expected.json
+++ b/packages/wasm-parser/test/fixtures/section-metadata/expected.json
@@ -52,7 +52,7 @@
           "type": "Func",
           "name": {
             "type": "Identifier",
-            "value": "func_1"
+            "value": "a"
           },
           "params": [],
           "result": [],
@@ -78,7 +78,7 @@
             "type": "Func",
             "id": {
               "type": "Identifier",
-              "value": "func_1"
+              "value": "a"
             }
           },
           "loc": {
@@ -94,6 +94,7 @@
         }
       ],
       "metadata": {
+        "type": "ModuleMetadata",
         "sections": [
           {
             "type": "SectionMetadata",
@@ -143,6 +144,13 @@
             "startOffset": 41,
             "size": 16,
             "vectorOfSize": -1
+          }
+        ],
+        "functionNames": [
+          {
+            "type": "FunctionNameMetadata",
+            "value": "a",
+            "index": 0
           }
         ]
       }

--- a/packages/wasm-parser/test/fixtures/start-func/expected.json
+++ b/packages/wasm-parser/test/fixtures/start-func/expected.json
@@ -113,7 +113,7 @@
           "type": "Func",
           "name": {
             "type": "Identifier",
-            "value": "func_1"
+            "value": "func_0"
           },
           "params": [],
           "result": [],
@@ -165,6 +165,7 @@
         }
       ],
       "metadata": {
+        "type": "ModuleMetadata",
         "sections": [
           {
             "type": "SectionMetadata",

--- a/packages/wasm-parser/test/fixtures/with-import/expected.json
+++ b/packages/wasm-parser/test/fixtures/with-import/expected.json
@@ -77,7 +77,7 @@
           "type": "Func",
           "name": {
             "type": "Identifier",
-            "value": "func_1"
+            "value": "func_0"
           },
           "params": [
             {
@@ -146,7 +146,7 @@
             "type": "Func",
             "id": {
               "type": "Identifier",
-              "value": "func_1"
+              "value": "func_0"
             }
           },
           "loc": {
@@ -162,6 +162,7 @@
         }
       ],
       "metadata": {
+        "type": "ModuleMetadata",
         "sections": [
           {
             "type": "SectionMetadata",

--- a/types/AST.js
+++ b/types/AST.js
@@ -75,13 +75,14 @@ type NodePath<T> = {
 type Node =
   | Program
   | FloatLiteral
-  | Program
+  | ModuleMetadata
   | StringLiteral
   | NumberLiteral
   | LongNumberLiteral
   | Identifier
   | Module
   | SectionMetadata
+  | FunctionNameMetadata
   | BinaryModule
   | QuoteModule
   | Func
@@ -201,7 +202,19 @@ type Module = {
 };
 
 type ModuleMetadata = {
-  sections: Array<SectionMetadata>
+  ...BaseNode,
+
+  type: "ModuleMetadata",
+  sections: Array<SectionMetadata>,
+  functionNames?: Array<FunctionNameMetadata>
+};
+
+type FunctionNameMetadata = {
+  ...BaseNode,
+
+  type: "FunctionNameMetadata",
+  value: string,
+  index: number
 };
 
 type SectionMetadata = {


### PR DESCRIPTION
This PR adds logic to the wasm-parser to decode custom name sections, fixes #202 

Changes in this PR:
 - wasm-parser tests no longer have binary wasm files as test cases, they instead use wat files which are transformed to wasm via `wat2wasm` (I'm not sure how we make this a proper dependency?)
 - wasm-parser parses the custom name section generated by `wat2wasm --debug-names`. Currently it only parses the function name sub-section. I'll look at adding local names next. Names are stored in the module-metadata (which I've restructured a bit to make it easier to walk).
 - wasm-parser walks the AST, after decoding, to apply names. I've added an option to disable this behaviour as desired, as there will be a performance impact.

TODO:
 - [x] work out how make `wat2wasm` available to travis
 - [x] fix flow errors!
