### PR TITLE
support for call_indirect in the wasm parser

### DIFF
--- a/packages/wasm-edit/test/replace-node.js
+++ b/packages/wasm-edit/test/replace-node.js
@@ -139,7 +139,7 @@ describe("replace a node", () => {
     const newBinary = edit(actualBinary, {
       Instr(path) {
         if (path.node.id === "get_global") {
-          const newNode = t.callIndirectInstructionIndex(t.indexLiteral(2));
+          const newNode = t.callIndirectInstructionIndex(t.indexLiteral(0));
           path.replaceWith(newNode);
         }
       }
@@ -157,7 +157,7 @@ describe("replace a node", () => {
       [constants.sections.type, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f],
       [constants.sections.func, 0x02, 0x01, 0x00],
       [constants.sections.global, 0x06, 0x01, 0x7f, 0x00, 0x41, 0x01, 0x0b],
-      [constants.sections.code, 0x07, 0x01, 0x05, 0x00, 0x11, 0x02, 0x00, 0x0b]
+      [constants.sections.code, 0x07, 0x01, 0x05, 0x00, 0x11, 0x00, 0x00, 0x0b]
     );
 
     compareArrayBuffers(newBinary, expectedBinary);

--- a/packages/wasm-parser/src/decoder.js
+++ b/packages/wasm-parser/src/decoder.js
@@ -736,6 +736,18 @@ export function decode(ab: ArrayBuffer, opts: DecoderOpts): Program {
 
         code.push(callNode);
         instructionAlreadyCreated = true;
+      } else if (instruction.name === "call_indirect") {
+        const indexu32 = readU32();
+        const index = indexu32.value;
+        eatBytes(indexu32.nextIndex);
+        eatBytes(1);
+
+        dump([index], "index");
+
+        const callNode = t.callIndirectInstruction([], [], []);
+
+        code.push(callNode);
+        instructionAlreadyCreated = true;
       } else if (instruction.name === "br_table") {
         const indicesu32 = readU32();
         const indices = indicesu32.value;

--- a/packages/wasm-parser/src/decoder.js
+++ b/packages/wasm-parser/src/decoder.js
@@ -737,14 +737,27 @@ export function decode(ab: ArrayBuffer, opts: DecoderOpts): Program {
         code.push(callNode);
         instructionAlreadyCreated = true;
       } else if (instruction.name === "call_indirect") {
-        const indexu32 = readU32();
-        const index = indexu32.value;
-        eatBytes(indexu32.nextIndex);
-        eatBytes(1);
+        const indexU32 = readU32();
+        const typeindex = indexU32.value;
+        eatBytes(indexU32.nextIndex);
 
-        dump([index], "index");
+        dump([typeindex], "type index");
 
-        const callNode = t.callIndirectInstruction([], [], []);
+        const signature = state.typesInModule[typeindex];
+
+        if (typeof signature === "undefined") {
+          throw new CompileError(
+            `call_indirect signature not found (${typeindex})`
+          );
+        }
+
+        const callNode = t.callIndirectInstruction(
+          signature.params,
+          signature.result,
+          []
+        );
+
+        eatBytes(1); // 0x00 - reserved byte
 
         code.push(callNode);
         instructionAlreadyCreated = true;

--- a/packages/wasm-parser/test/fixtures/call_indirect/actual.wat
+++ b/packages/wasm-parser/test/fixtures/call_indirect/actual.wat
@@ -1,0 +1,7 @@
+(module
+  (func
+    (i32.const 0)
+    (i32.const 2)
+    (call_indirect)
+  )
+)

--- a/packages/wasm-parser/test/fixtures/call_indirect/no-args/actual.wat
+++ b/packages/wasm-parser/test/fixtures/call_indirect/no-args/actual.wat
@@ -1,7 +1,6 @@
 (module
   (func
     (i32.const 0)
-    (i32.const 2)
     (call_indirect)
   )
 )

--- a/packages/wasm-parser/test/fixtures/call_indirect/with-params/actual.wat
+++ b/packages/wasm-parser/test/fixtures/call_indirect/with-params/actual.wat
@@ -1,0 +1,6 @@
+(module
+  (func
+    (i32.const 0)
+    (call_indirect (param i32) (result i32))
+  )
+)

--- a/packages/wasm-parser/test/fixtures/call_indirect/with-return/actual.wat
+++ b/packages/wasm-parser/test/fixtures/call_indirect/with-return/actual.wat
@@ -1,0 +1,6 @@
+(module
+  (func
+    (i32.const 0)
+    (call_indirect (result i32))
+  )
+)

--- a/packages/wasm-parser/test/fixtures/func/anonymous-empty-func/actual.wat
+++ b/packages/wasm-parser/test/fixtures/func/anonymous-empty-func/actual.wat
@@ -1,0 +1,3 @@
+(module
+  (func)
+)

--- a/packages/wasm-parser/test/fixtures/func/anonymous-func-with-body/actual.wat
+++ b/packages/wasm-parser/test/fixtures/func/anonymous-func-with-body/actual.wat
@@ -1,0 +1,5 @@
+(module
+  (func
+    (i32.add)
+  )
+)

--- a/packages/wasm-parser/test/fixtures/func/anonymous-func-with-multiple-params/actual.wat
+++ b/packages/wasm-parser/test/fixtures/func/anonymous-func-with-multiple-params/actual.wat
@@ -1,0 +1,5 @@
+(module
+  (func (param i32 i64 i32))
+  (func (param f64 i32))
+  (func (param f64 f64 f64 f64 f32 f32 f32 i32 i64))
+)

--- a/packages/wasm-parser/test/fixtures/func/anonymous-func-with-param/actual.wat-failure
+++ b/packages/wasm-parser/test/fixtures/func/anonymous-func-with-param/actual.wat-failure
@@ -1,0 +1,7 @@
+;; named params have not been implemented in wasm parser yet
+(module 
+  (func (param $p i32))
+  (func (param $P i64))
+  (func (param $$ f32))
+  (func (param $$ f64))
+)

--- a/packages/wasm-parser/test/fixtures/func/anonymous-func-with-params-and-result/actual.wat-failure
+++ b/packages/wasm-parser/test/fixtures/func/anonymous-func-with-params-and-result/actual.wat-failure
@@ -1,0 +1,4 @@
+;; named params have not been implemented in wasm parser yet
+(module
+  (func (param $a i32) (param $b i32) (result i32))
+)

--- a/packages/wasm-parser/test/fixtures/func/anonymous-func-with-result/actual.wat
+++ b/packages/wasm-parser/test/fixtures/func/anonymous-func-with-result/actual.wat
@@ -1,0 +1,3 @@
+(module
+  (func (result i32))
+)

--- a/packages/wasm-parser/test/fixtures/func/named-empty-func/actual.wat
+++ b/packages/wasm-parser/test/fixtures/func/named-empty-func/actual.wat
@@ -1,0 +1,6 @@
+(module
+  (func $test)
+  (func $TEST)
+  (func $!)
+  (func $$)
+)

--- a/packages/wasm-parser/test/fixtures/func/named-func-with-multiple-instructions-and-multiple-params/actual.wat-failure
+++ b/packages/wasm-parser/test/fixtures/func/named-func-with-multiple-instructions-and-multiple-params/actual.wat-failure
@@ -1,0 +1,8 @@
+;; named params have not been implemented in wasm parser yet
+(module
+  (func $add (param $lhs i32) (param $rhs i32) (result i32)
+    (get_local 0)
+    (get_local 1)
+    (i32.add)
+  )
+)

--- a/packages/wasm-parser/test/fixtures/func/with-shorthand-export/actual.wat-failure
+++ b/packages/wasm-parser/test/fixtures/func/with-shorthand-export/actual.wat-failure
@@ -1,4 +1,4 @@
-;; shorthand export not implemented yet
+;; shorthand exports results in structural differences between WASM / WAT parser
 (module
   (func (export "a"))
   (func (export "b") (result i32))

--- a/packages/wasm-parser/test/fixtures/func/with-shorthand-export/actual.wat-failure
+++ b/packages/wasm-parser/test/fixtures/func/with-shorthand-export/actual.wat-failure
@@ -1,0 +1,6 @@
+;; shorthand export not implemented yet
+(module
+  (func (export "a"))
+  (func (export "b") (result i32))
+  (func (export "c") (param i32))
+)


### PR DESCRIPTION
Follows a similar pattern to the way functions are parsed, the type information is looked up and added to the AST giving the same output as the WAT parser. 