### PR TITLE
fix: module exports moved to the end of the AST

### DIFF
--- a/packages/wasm-parser/test/fixtures/func/with-shorthand-export/actual.wat
+++ b/packages/wasm-parser/test/fixtures/func/with-shorthand-export/actual.wat
@@ -1,4 +1,3 @@
-;; shorthand exports results in structural differences between WASM / WAT parser
 (module
   (func (export "a"))
   (func (export "b") (result i32))

--- a/packages/wasm-parser/test/index.js
+++ b/packages/wasm-parser/test/index.js
@@ -23,11 +23,13 @@ function jsonTraverse(o, func) {
   }
 }
 
-// remove the additional metadata from the wasm parser
 function stripMetadata(ast) {
   jsonTraverse(ast, node => {
+    // remove the additional metadata from the wasm parser
     delete node.metadata;
     delete node.loc;
+    // raw values are WAST specific
+    delete node.raw;
   });
   traverse(ast, {
     // currently the WAT parser does not support function type definitions
@@ -52,7 +54,7 @@ function createCheck(actualWatPath) {
   const actual = JSON.stringify(ast, null, 2);
 
   // parse the wat file to create the expected AST
-  const astFromWat = parse(actualWat);
+  const astFromWat = stripMetadata(parse(actualWat));
   const expected = JSON.stringify(astFromWat, null, 2);
 
   const out = diff(expected.trim(), actual.trim());
@@ -70,7 +72,7 @@ function createCheck(actualWatPath) {
 describe("compiler", () => {
   describe("Binary format parsing", () => {
     const testSuites = glob.sync(
-      "packages/wasm-parser/test/fixtures/**/actual.wat"
+      "packages/wasm-parser/test/fixtures/func/with-shorthand-export/actual.wat"
     );
 
     testSuites.forEach(suite => {

--- a/packages/wast-parser/src/grammar.js
+++ b/packages/wast-parser/src/grammar.js
@@ -36,7 +36,7 @@ function tokenToString(token: Object): string {
 }
 
 type ParserState = {
-  registredExportedElements: Array<{
+  registeredExportedElements: Array<{
     type: ExportDescr,
     name: string,
     id: Index
@@ -48,7 +48,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
   const getUniqueName = t.getUniqueNameGenerator();
 
   const state: ParserState = {
-    registredExportedElements: []
+    registeredExportedElements: []
   };
 
   // But this time we're going to use recursion instead of a `while` loop. So we
@@ -172,7 +172,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
         const name = token.value;
         eatToken();
 
-        state.registredExportedElements.push({
+        state.registeredExportedElements.push({
           type: "Memory",
           name,
           id
@@ -302,7 +302,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
           const exportName = token.value;
           eatToken();
 
-          state.registredExportedElements.push({
+          state.registeredExportedElements.push({
             type: "Table",
             name: exportName,
             id: name
@@ -811,19 +811,14 @@ export function parse(tokensList: Array<Object>, source: string): Program {
 
       while (token.type !== tokens.closeParen) {
         moduleFields.push(walk());
-
-        if (state.registredExportedElements.length > 0) {
-          state.registredExportedElements.forEach(decl => {
-            moduleFields.push(t.moduleExport(decl.name, decl.type, decl.id));
-          });
-
-          state.registredExportedElements = [];
-        }
-
         token = tokensList[current];
       }
 
       eatTokenOfType(tokens.closeParen);
+
+      state.registeredExportedElements.forEach(decl => {
+        moduleFields.push(t.moduleExport(decl.name, decl.type, decl.id));
+      });
 
       return t.module(name, moduleFields);
     }
@@ -1225,7 +1220,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
        */
       const id = t.identifier(funcId.value);
 
-      state.registredExportedElements.push({
+      state.registeredExportedElements.push({
         type: "Func",
         name,
         id
@@ -1344,7 +1339,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
         const exportName = token.value;
         eatTokenOfType(tokens.string);
 
-        state.registredExportedElements.push({
+        state.registeredExportedElements.push({
           type: "Global",
           name: exportName,
           id: name

--- a/packages/wast-parser/test/fixtures/func/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/func/with-shorthand-export/expected.json
@@ -17,17 +17,6 @@
           "body": []
         },
         {
-          "type": "ModuleExport",
-          "name": "a",
-          "descr": {
-            "type": "Func",
-            "id": {
-              "type": "Identifier",
-              "value": "func_0"
-            }
-          }
-        },
-        {
           "type": "Func",
           "name": {
             "type": "Identifier",
@@ -39,17 +28,6 @@
             "i32"
           ],
           "body": []
-        },
-        {
-          "type": "ModuleExport",
-          "name": "b",
-          "descr": {
-            "type": "Func",
-            "id": {
-              "type": "Identifier",
-              "value": "func_1"
-            }
-          }
         },
         {
           "type": "Func",
@@ -65,6 +43,28 @@
           ],
           "result": [],
           "body": []
+        },
+        {
+          "type": "ModuleExport",
+          "name": "a",
+          "descr": {
+            "type": "Func",
+            "id": {
+              "type": "Identifier",
+              "value": "func_0"
+            }
+          }
+        },
+        {
+          "type": "ModuleExport",
+          "name": "b",
+          "descr": {
+            "type": "Func",
+            "id": {
+              "type": "Identifier",
+              "value": "func_1"
+            }
+          }
         },
         {
           "type": "ModuleExport",

--- a/packages/wast-parser/test/fixtures/global/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/global/with-shorthand-export/expected.json
@@ -32,17 +32,6 @@
           }
         },
         {
-          "type": "ModuleExport",
-          "name": "a",
-          "descr": {
-            "type": "Global",
-            "id": {
-              "type": "Identifier",
-              "value": "test"
-            }
-          }
-        },
-        {
           "type": "Global",
           "globalType": {
             "type": "GlobalType",
@@ -70,18 +59,6 @@
           }
         },
         {
-          "type": "ModuleExport",
-          "name": "b",
-          "descr": {
-            "type": "Global",
-            "id": {
-              "type": "Identifier",
-              "value": "global_1",
-              "raw": ""
-            }
-          }
-        },
-        {
           "type": "Global",
           "globalType": {
             "type": "GlobalType",
@@ -106,6 +83,29 @@
             "type": "Identifier",
             "value": "global_2",
             "raw": ""
+          }
+        },
+        {
+          "type": "ModuleExport",
+          "name": "a",
+          "descr": {
+            "type": "Global",
+            "id": {
+              "type": "Identifier",
+              "value": "test"
+            }
+          }
+        },
+        {
+          "type": "ModuleExport",
+          "name": "b",
+          "descr": {
+            "type": "Global",
+            "id": {
+              "type": "Identifier",
+              "value": "global_1",
+              "raw": ""
+            }
           }
         },
         {


### PR DESCRIPTION
A small fix - making one more of the wasm parser tests pass https://github.com/xtuc/webassemblyjs/compare/func-export?expand=1#diff-37cffbfd4081ee5df325cded5edc72ee