### PR TITLE
fix(repl): assert type too

### DIFF
--- a/packages/webassemblyjs/src/interpreter/host-func.js
+++ b/packages/webassemblyjs/src/interpreter/host-func.js
@@ -15,7 +15,7 @@ export function createHostfunc(
   moduleinst: ModuleInstance,
   exportinst: ExportInstance,
   allocator: Allocator,
-  { checkForI64InSignature }: InternalInstanceOptions
+  { checkForI64InSignature, returnStackLocal }: InternalInstanceOptions
 ): Hostfunc {
   return function hostfunc(...args): ?any {
     const exportinstAddr = exportinst.value.addr;
@@ -150,13 +150,20 @@ export function createHostfunc(
 
     // stackFrame.trace = trace;
 
-    return executeStackFrameAndGetResult(stackFrame);
+    return executeStackFrameAndGetResult(stackFrame, returnStackLocal);
   };
 }
 
-export function executeStackFrameAndGetResult(stackFrame: StackFrame): any {
+export function executeStackFrameAndGetResult(
+  stackFrame: StackFrame,
+  returnStackLocal: boolean
+): any {
   try {
     const res = executeStackFrame(stackFrame);
+
+    if (returnStackLocal === true) {
+      return res;
+    }
 
     if (res != null && res.value != null) {
       return res.value.toNumber();

--- a/packages/webassemblyjs/src/interpreter/index.js
+++ b/packages/webassemblyjs/src/interpreter/index.js
@@ -42,7 +42,8 @@ export class Instance {
      * Pass internal options
      */
     let internalInstanceOptions: InternalInstanceOptions = {
-      checkForI64InSignature: true
+      checkForI64InSignature: true,
+      returnStackLocal: false
     };
 
     if (typeof importObject._internalInstanceOptions === "object") {
@@ -94,7 +95,11 @@ export class Instance {
           throw new RuntimeError("Global instance has not been instantiated");
         }
 
-        this.exports[exportinst.name] = globalinst.value.toNumber();
+        if (internalInstanceOptions.returnStackLocal === true) {
+          this.exports[exportinst.name] = globalinst;
+        } else {
+          this.exports[exportinst.name] = globalinst.value.toNumber();
+        }
       }
 
       if (exportinst.value.type === "Memory") {
@@ -143,7 +148,7 @@ export class Instance {
     );
 
     // Ignore the result
-    executeStackFrameAndGetResult(stackFrame);
+    executeStackFrameAndGetResult(stackFrame, /* returnStackLocal */ true);
   }
 }
 

--- a/types/userland.js
+++ b/types/userland.js
@@ -48,5 +48,6 @@ type InstansitatedInstanceAndModule = {
 };
 
 type InternalInstanceOptions = {
-  checkForI64InSignature: boolean
+  checkForI64InSignature: boolean,
+  returnStackLocal: boolean
 };


### PR DESCRIPTION
I forgot to test the type of the value as well as the value.

This was valid before:
```wat
(module
  (func (export "get") (result i32)
    (i32.const 1)
  )
)

(assert_return (invoke "get") (f32.const 1))
```

And now asserts correctly: `Error: assertion failure: Type expected "f32", "i32" given`.