### PR TITLE
Fix token locations

### DIFF
--- a/packages/wast-parser/src/tokenizer.js
+++ b/packages/wast-parser/src/tokenizer.js
@@ -261,9 +261,6 @@ function tokenize(input: string) {
         }
       }
 
-      // Shift by the length of the string
-      column += text.length;
-
       pushCommentToken(text, { type: "leading" });
 
       continue;
@@ -287,14 +284,12 @@ function tokenize(input: string) {
 
         text += char;
 
+        eatCharacter();
+
         if (isNewLine(char)) {
           line++;
           column = 0;
-        } else {
-          column++;
         }
-
-        eatCharacter();
       }
 
       pushCommentToken(text, { type: "block" });
@@ -345,9 +340,6 @@ function tokenize(input: string) {
         eatCharacter();
       }
 
-      // Shift by the length of the string
-      column += value.length;
-
       pushIdentifierToken(value);
 
       continue;
@@ -388,9 +380,6 @@ function tokenize(input: string) {
         value += char;
         eatCharacter();
       }
-
-      // Shift by the length of the string
-      column += value.length;
 
       eatCharacter();
 
@@ -441,9 +430,6 @@ function tokenize(input: string) {
       if (typeof keywords[value] === "string") {
         pushKeywordToken(value);
 
-        // Shift by the length of the string
-        column += value.length;
-
         continue;
       }
 
@@ -453,9 +439,6 @@ function tokenize(input: string) {
       if (valtypes.indexOf(value) !== -1) {
         pushValtypeToken(value);
 
-        // Shift by the length of the string
-        column += value.length;
-
         continue;
       }
 
@@ -463,9 +446,6 @@ function tokenize(input: string) {
        * Handle literals
        */
       pushNameToken(value);
-
-      // Shift by the length of the string
-      column += value.length;
 
       continue;
     }

--- a/packages/wast-parser/test/fixtures/export/invalid/actual.wast
+++ b/packages/wast-parser/test/fixtures/export/invalid/actual.wast
@@ -1,2 +1,1 @@
 (func (export a))
-(func (export 1))

--- a/packages/wast-parser/test/fixtures/export/invalid/throws.txt
+++ b/packages/wast-parser/test/fixtures/export/invalid/throws.txt
@@ -1,6 +1,5 @@
 (func (export a))
-                         ^
-(func (export 1))
+               ^
 
 
 Function export expected a string, given name

--- a/packages/wast-parser/test/fixtures/func/invalid-body/throws.txt
+++ b/packages/wast-parser/test/fixtures/func/invalid-body/throws.txt
@@ -1,5 +1,5 @@
 (func (func))
-               ^
+           ^
 
 
 Unexpected instruction in function body, given keyword (func)

--- a/packages/wast-parser/test/fixtures/func/invalid-result/throws.txt
+++ b/packages/wast-parser/test/fixtures/func/invalid-result/throws.txt
@@ -1,5 +1,5 @@
 (func (result 1))
-                        ^
+              ^
 
 
 Unexpected token in func result, given number


### PR DESCRIPTION
Closes https://github.com/xtuc/webassemblyjs/issues/252

Great moment of engineering

```diff
--- a/packages/wast-parser/src/tokenizer.js
+++ b/packages/wast-parser/src/tokenizer.js
@@ -261,9 +261,6 @@ function tokenize(input: string) {
         }
       }
-      // Shift by the length of the string
-      column += text.length;
-
       pushCommentToken(text, { type: "leading" });
       continue;
@@ -287,14 +284,12 @@ function tokenize(input: string) {
         text += char;
+        eatCharacter();
+
         if (isNewLine(char)) {
           line++;
           column = 0;
-        } else {
-          column++;
         }
-
-        eatCharacter();
       }
       pushCommentToken(text, { type: "block" });
@@ -345,9 +340,6 @@ function tokenize(input: string) {
         eatCharacter();
       }
-      // Shift by the length of the string
-      column += value.length;
-
       pushIdentifierToken(value);
       continue;
@@ -389,9 +381,6 @@ function tokenize(input: string) {
         eatCharacter();
       }
-      // Shift by the length of the string
-      column += value.length;
-
       eatCharacter();
       pushStringToken(value);
@@ -441,9 +430,6 @@ function tokenize(input: string) {
       if (typeof keywords[value] === "string") {
         pushKeywordToken(value);
-        // Shift by the length of the string
-        column += value.length;
-
         continue;
```

GitHub diff is unusable, see ^