### PR TITLE
Fix typo in README: wast-strip -> wasm-strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ See [WebAssembly.js.org](https://webassembly.js.org) for more information.
 - [wasm-gen](https://github.com/xtuc/webassemblyjs/tree/master/packages/wasm-gen) - WebAssembly binary format printer
 - [wasm-opt](https://github.com/xtuc/webassemblyjs/tree/master/packages/wasm-opt) - WASM optimizer
 - [wasm-parser](https://github.com/xtuc/webassemblyjs/tree/master/packages/wasm-parser) - WebAssembly binary format parser
+- [wasm-strip](https://github.com/xtuc/webassemblyjs/tree/master/packages/wasm-strip) - Strips custom sections
 - [wast-parser](https://github.com/xtuc/webassemblyjs/tree/master/packages/wast-parser) - WebAssembly text format parser
 - [wast-printer](https://github.com/xtuc/webassemblyjs/tree/master/packages/wast-printer) - WebAssembly text format printer
 - [wast-refmt](https://github.com/xtuc/webassemblyjs/tree/master/packages/wast-refmt) - WAST refmt
-- [wast-strip](https://github.com/xtuc/webassemblyjs/tree/master/packages/wast-strip) - Strips custom sections
 - [webassemblyjs](https://github.com/xtuc/webassemblyjs/tree/master/packages/webassemblyjs) - WebAssembly interpreter, implements the W3C WebAssembly API.
 
 ## Licence


### PR DESCRIPTION
I came across a broken link and just fixed it. 