### PR TITLE
Fix tests in wasm-parser

### DIFF
--- a/packages/wasm-parser/test/fixtures/import/actual.wat
+++ b/packages/wasm-parser/test/fixtures/import/actual.wat
@@ -1,0 +1,5 @@
+(module
+  (import "a" "b" (func))
+  (import "a" "c" (func (param i32)))
+  (import "a" "c" (func (param i32) (result i32)))
+)

--- a/packages/wasm-parser/test/index.js
+++ b/packages/wasm-parser/test/index.js
@@ -44,7 +44,7 @@ describe("Binary decoder", () => {
 
     // read the WASM file and strip custom metadata
     const ast = stripMetadata(decode(buffer));
-    const actual = JSON.stringify(ast, Object.keys(ast).sort(), 2);
+    const actual = JSON.stringify(ast, null, 2);
 
     return actual;
   };
@@ -53,11 +53,7 @@ describe("Binary decoder", () => {
     // parse the wat file to create the expected AST
     const astFromWat = parse(f);
 
-    const expected = JSON.stringify(
-      astFromWat,
-      Object.keys(astFromWat).sort(),
-      2
-    );
+    const expected = JSON.stringify(astFromWat, null, 2);
 
     return expected;
   };


### PR DESCRIPTION
I noticed that our `wasm-parser` tests were inactive.

The actual and expected JSON was:

```json
 {
  "body": [
    {
      "type": "Module"
    }
  ],
  "type": "Program"
}
```

It seems to be caused by the replacer.

cc @ColinEberhardt 