### PR TITLE
Traverse refactor

### DIFF
--- a/packages/ast/src/index.js
+++ b/packages/ast/src/index.js
@@ -173,14 +173,14 @@ export function quoteModule(id: ?string, string: Array<string>): QuoteModule {
 
 export function moduleExport(
   name: string,
-  type: ExportDescr,
+  exportType: ExportDescr,
   id: Index
 ): ModuleExport {
   return {
     type: "ModuleExport",
     name,
     descr: {
-      type,
+      exportType,
       id
     }
   };

--- a/packages/ast/src/index.js
+++ b/packages/ast/src/index.js
@@ -173,13 +173,14 @@ export function quoteModule(id: ?string, string: Array<string>): QuoteModule {
 
 export function moduleExport(
   name: string,
-  exportType: ExportDescr,
+  exportType: ExportDescrType,
   id: Index
 ): ModuleExport {
   return {
     type: "ModuleExport",
     name,
     descr: {
+      type: "ModuleExportDescr",
       exportType,
       id
     }

--- a/packages/ast/src/traverse.js
+++ b/packages/ast/src/traverse.js
@@ -93,212 +93,22 @@ function walk(n: Node, cb: Cb, parentPath: ?NodePath<Node>) {
     return;
   }
 
-  switch (n.type) {
-    case "Program": {
-      const path = createPath(n, parentPath);
-      cb(n.type, path);
+  const path = createPath(n, parentPath);
+  // $FlowIgnore
+  cb(n.type, path);
 
-      n.body.forEach(x => walk(x, cb, path));
-
-      break;
+  Object.keys(n).forEach((prop: string) => {
+    const value = n[prop];
+    if (!value) {
+      return;
     }
-
-    case "SectionMetadata":
-    case "FunctionNameMetadata":
-    case "ModuleNameMetadata":
-    case "LocalNameMetadata":
-    case "Data":
-    case "Memory":
-    case "Elem":
-    case "FuncImportDescr":
-    case "GlobalType":
-    case "NumberLiteral":
-    case "ValtypeLiteral":
-    case "FloatLiteral":
-    case "StringLiteral":
-    case "QuoteModule":
-    case "LongNumberLiteral":
-    case "BinaryModule":
-    case "LeadingComment":
-    case "BlockComment":
-    case "Identifier": {
-      cb(n.type, createPath(n, parentPath));
-      break;
-    }
-
-    case "ModuleExport": {
-      const path = createPath(n, parentPath);
-      cb(n.type, path);
-
-      walk(n.descr.id, cb, path);
-
-      break;
-    }
-
-    case "ModuleMetadata": {
-      const path = createPath(n, parentPath);
-      cb(n.type, path);
-      n.sections.forEach(x => walk(x, cb, path));
-
-      if (typeof n.functionNames !== "undefined") {
-        // $FlowIgnore
-        n.functionNames.forEach(x => walk(x, cb, path));
+    const valueAsArray = Array.isArray(value) ? value : [value];
+    valueAsArray.forEach(v => {
+      if (v.hasOwnProperty("type")) {
+        walk(v, cb, path);
       }
-
-      if (typeof n.localNames !== "undefined") {
-        // $FlowIgnore
-        n.localNames.forEach(x => walk(x, cb, path));
-      }
-      break;
-    }
-
-    case "Module": {
-      const path = createPath(n, parentPath);
-      cb(n.type, path);
-
-      if (typeof n.fields !== "undefined") {
-        n.fields.forEach(x => walk(x, cb, path));
-      }
-
-      if (typeof n.metadata !== "undefined") {
-        // $FlowIgnore
-        walk(n.metadata, cb, path);
-      }
-
-      break;
-    }
-
-    case "Start":
-    case "CallInstruction": {
-      const path = createPath(n, parentPath);
-      // $FlowIgnore
-      cb(n.type, path);
-
-      // $FlowIgnore
-      walk(n.index, cb, path);
-
-      break;
-    }
-
-    case "CallIndirectInstruction": {
-      const path = createPath(n, parentPath);
-      // $FlowIgnore
-      cb(n.type, path);
-
-      if (n.index != null) {
-        // $FlowIgnore
-        walk(n.index, cb, path);
-      }
-
-      break;
-    }
-
-    case "ModuleImport": {
-      cb(n.type, createPath(n, parentPath));
-
-      if (n.descr != null) {
-        // $FlowIgnore
-        walk(n.descr, cb, createPath(n, parentPath));
-      }
-
-      break;
-    }
-
-    case "Table":
-    case "Global": {
-      const path = createPath(n, parentPath);
-      cb(n.type, path);
-
-      if (n.name != null) {
-        walk(n.name, cb, path);
-      }
-
-      if (n.init != null) {
-        // $FlowIgnore
-        n.init.forEach(x => walk(x, cb, path));
-      }
-
-      break;
-    }
-
-    case "TypeInstruction": {
-      const path = createPath(n, parentPath);
-      cb(n.type, path);
-
-      if (n.id != null) {
-        walk(n.id, cb, path);
-      }
-
-      break;
-    }
-
-    case "IfInstruction": {
-      const path = createPath(n, parentPath);
-
-      // $FlowIgnore
-      cb(n.type, path);
-
-      // $FlowIgnore
-      n.test.forEach(x => walk(x, cb, path));
-      // $FlowIgnore
-      n.consequent.forEach(x => walk(x, cb, path));
-      // $FlowIgnore
-      n.alternate.forEach(x => walk(x, cb, path));
-
-      // $FlowIgnore
-      walk(n.testLabel, cb, path);
-
-      break;
-    }
-
-    case "Instr": {
-      const path = createPath(n, parentPath);
-      // $FlowIgnore
-      cb(n.type, path);
-
-      // $FlowIgnore
-      if (typeof n.args === "object") {
-        n.args.forEach(x => walk(x, cb, path));
-      }
-
-      break;
-    }
-
-    case "BlockInstruction":
-    case "LoopInstruction": {
-      const path = createPath(n, parentPath);
-      // $FlowIgnore
-      cb(n.type, path);
-
-      if (n.label != null) {
-        // $FlowIgnore
-        walk(n.label, cb, path);
-      }
-
-      // $FlowIgnore
-      n.instr.forEach(x => walk(x, cb, path));
-
-      break;
-    }
-
-    case "Func": {
-      const path = createPath(n, parentPath);
-      cb(n.type, path);
-
-      n.body.forEach(x => walk(x, cb, path));
-
-      if (n.name != null) {
-        walk(n.name, cb, path);
-      }
-
-      break;
-    }
-
-    default:
-      throw new Error(
-        "Unknown node encounter of type: " + JSON.stringify(n.type)
-      );
-  }
+    });
+  });
 }
 
 export function traverse(n: Node, visitors: Object) {

--- a/packages/ast/test/traverse.js
+++ b/packages/ast/test/traverse.js
@@ -21,6 +21,32 @@ describe("AST traverse", () => {
     assert.isTrue(called, "Module visitor has not been called");
   });
 
+  it("should be called once per node", () => {
+    const node = t.module("test", []);
+    let nb = 0;
+
+    traverse(node, {
+      Module() {
+        nb++;
+      }
+    });
+
+    assert.equal(nb, 1);
+  });
+
+  it("should call the special Node visitor", () => {
+    const node = t.module("test", []);
+    let called = false;
+
+    traverse(node, {
+      Node() {
+        called = true;
+      }
+    });
+
+    assert.isTrue(called, "Module visitor has not been called");
+  });
+
   describe("parent path", () => {
     it("should retain the parent path", () => {
       const root = t.module("test", [t.func(null, [], [], [])]);

--- a/packages/cli/src/printer/fast-ast/index.js
+++ b/packages/cli/src/printer/fast-ast/index.js
@@ -21,7 +21,7 @@ export function print(ast: Node) {
 
   traverse(ast, {
     ModuleExport({ node }: NodePath<ModuleExport>) {
-      if (node.descr.type === "Func") {
+      if (node.descr.exportType === "Func") {
         out.exports[node.descr.id.value] = node;
       }
     },

--- a/packages/dce/src/reference-couting.js
+++ b/packages/dce/src/reference-couting.js
@@ -8,7 +8,7 @@ module.exports = function countRefByName(ast, name) {
       // We don't need to count the export, we are going to remove it aswell
       // that doesn't cover the case of exporting multiple times the same element
       // FIXME(sven): refactor this
-      if (parentPath.node.type === "ModuleExport") {
+      if (parentPath.node.type === "ModuleExportDescr") {
         return;
       }
 

--- a/packages/floating-point-hex-parser/package.json
+++ b/packages/floating-point-hex-parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webassemblyjs/floating-point-hex-parser",
   "scripts": {
-    "pretest": "[ -f ./test/fuzzing/parse.out ] || gcc ./test/fuzzing/parse.c -o ./test/fuzzing/parse.out -lm -Wall"
+    "build-fuzzer": "[ -f ./test/fuzzing/parse.out ] || gcc ./test/fuzzing/parse.c -o ./test/fuzzing/parse.out -lm -Wall"
   },
   "repository": {
     "type": "git",

--- a/packages/wasm-gen/src/encoder/index.js
+++ b/packages/wasm-gen/src/encoder/index.js
@@ -193,10 +193,10 @@ export function encodeModuleExport(n: ModuleExport): Array<Byte> {
 
   assertNotIdentifierNode(n.descr.id);
 
-  const exportTypeByteString = constants.exportTypesByName[n.descr.type];
+  const exportTypeByteString = constants.exportTypesByName[n.descr.exportType];
 
   if (typeof exportTypeByteString === "undefined") {
-    throw new Error("Unknown export of type: " + n.descr.type);
+    throw new Error("Unknown export of type: " + n.descr.exportType);
   }
 
   const exportTypeByte = parseInt(exportTypeByteString, 10);

--- a/packages/wasm-parser/src/index.js
+++ b/packages/wasm-parser/src/index.js
@@ -44,7 +44,7 @@ function restoreFunctionNames(ast) {
 
     // Also update the reference in the export
     ModuleExport({ node }: NodePath<ModuleExport>) {
-      if (node.descr.type === "Func") {
+      if (node.descr.exportType === "Func") {
         // $FlowIgnore
         const nodeName: Identifier = node.descr.id;
         const indexBasedFunctionName = nodeName.value;

--- a/packages/wasm-text-gen/src/printers/javascript.js
+++ b/packages/wasm-text-gen/src/printers/javascript.js
@@ -62,7 +62,7 @@ function genTemplate(fn, opts) {
 }
 
 function printExport(moduleExport, funcsTable) {
-  if (moduleExport.descr.type === "Func") {
+  if (moduleExport.descr.exportType === "Func") {
     const funcNode = funcsTable[moduleExport.descr.id.value];
 
     const params = funcNode.params

--- a/packages/wasm-text-gen/src/printers/markdown.js
+++ b/packages/wasm-text-gen/src/printers/markdown.js
@@ -1,7 +1,7 @@
 const { traverse } = require("@webassemblyjs/ast");
 
 function printExport(moduleExport, funcsTable) {
-  if (moduleExport.descr.type === "Func") {
+  if (moduleExport.descr.exportType === "Func") {
     const funcNode = funcsTable[moduleExport.descr.id.value];
     const params = funcNode.params.map(x => x.valtype).join(", ");
     const results = funcNode.result.join(", ") || "void";
@@ -9,7 +9,7 @@ function printExport(moduleExport, funcsTable) {
     return "- " + moduleExport.name + "(" + params + "): " + results;
   }
 
-  return "- Unknown (type " + moduleExport.descr.type + ")";
+  return "- Unknown (type " + moduleExport.descr.exportType + ")";
 }
 
 function printImport(moduleImport) {

--- a/packages/wasm-text-gen/src/printers/text.js
+++ b/packages/wasm-text-gen/src/printers/text.js
@@ -1,7 +1,7 @@
 const { traverse } = require("@webassemblyjs/ast");
 
 function printExport(moduleExport, funcsTable) {
-  if (moduleExport.descr.type === "Func") {
+  if (moduleExport.descr.exportType === "Func") {
     const funcNode = funcsTable[moduleExport.descr.id.value];
     const params = funcNode.params.map(x => x.valtype).join(", ");
     const results = funcNode.result.join(", ") || "void";
@@ -9,7 +9,7 @@ function printExport(moduleExport, funcsTable) {
     return "- " + moduleExport.name + "(" + params + "): " + results;
   }
 
-  return "- Unknown (type " + moduleExport.descr.type + ")";
+  return "- Unknown (type " + moduleExport.descr.exportType + ")";
 }
 
 function printImport(moduleImport) {

--- a/packages/wast-parser/src/grammar.js
+++ b/packages/wast-parser/src/grammar.js
@@ -45,7 +45,7 @@ function tokenToString(token: Object): string {
 
 type ParserState = {
   registredExportedElements: Array<{
-    type: ExportDescr,
+    exportType: ExportDescrType,
     name: string,
     id: Index
   }>
@@ -182,7 +182,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
         eatToken();
 
         state.registredExportedElements.push({
-          type: "Memory",
+          exportType: "Memory",
           name,
           id
         });
@@ -313,7 +313,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
           eatToken();
 
           state.registredExportedElements.push({
-            type: "Table",
+            exportType: "Table",
             name: exportName,
             id: name
           });
@@ -875,7 +875,9 @@ export function parse(tokensList: Array<Object>, source: string): Program {
 
         if (state.registredExportedElements.length > 0) {
           state.registredExportedElements.forEach(decl => {
-            moduleFields.push(t.moduleExport(decl.name, decl.type, decl.id));
+            moduleFields.push(
+              t.moduleExport(decl.name, decl.exportType, decl.id)
+            );
           });
 
           state.registredExportedElements = [];
@@ -1263,7 +1265,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
       const id = t.identifier(funcId.value);
 
       state.registredExportedElements.push({
-        type: "Func",
+        exportType: "Func",
         name,
         id
       });
@@ -1399,7 +1401,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
         eatTokenOfType(tokens.string);
 
         state.registredExportedElements.push({
-          type: "Global",
+          exportType: "Global",
           name: exportName,
           id: name
         });

--- a/packages/wast-parser/test/fixtures/export/global/expected.json
+++ b/packages/wast-parser/test/fixtures/export/global/expected.json
@@ -46,7 +46,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
-            "type": "Global",
+            "exportType": "Global",
             "id": {
               "type": "Identifier",
               "value": "global_0",
@@ -94,7 +94,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
-            "type": "Global",
+            "exportType": "Global",
             "id": {
               "type": "Identifier",
               "value": "g1"

--- a/packages/wast-parser/test/fixtures/export/global/expected.json
+++ b/packages/wast-parser/test/fixtures/export/global/expected.json
@@ -46,6 +46,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Global",
             "id": {
               "type": "Identifier",
@@ -94,6 +95,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Global",
             "id": {
               "type": "Identifier",

--- a/packages/wast-parser/test/fixtures/export/memory/expected.json
+++ b/packages/wast-parser/test/fixtures/export/memory/expected.json
@@ -21,7 +21,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
-            "type": "Memory",
+            "exportType": "Memory",
             "id": {
               "type": "Identifier",
               "value": "memory_0",

--- a/packages/wast-parser/test/fixtures/export/memory/expected.json
+++ b/packages/wast-parser/test/fixtures/export/memory/expected.json
@@ -21,6 +21,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Memory",
             "id": {
               "type": "Identifier",

--- a/packages/wast-parser/test/fixtures/export/table/expected.json
+++ b/packages/wast-parser/test/fixtures/export/table/expected.json
@@ -22,6 +22,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Table",
             "id": {
               "type": "Identifier",

--- a/packages/wast-parser/test/fixtures/export/table/expected.json
+++ b/packages/wast-parser/test/fixtures/export/table/expected.json
@@ -22,7 +22,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
-            "type": "Table",
+            "exportType": "Table",
             "id": {
               "type": "Identifier",
               "value": "table_0",

--- a/packages/wast-parser/test/fixtures/func/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/func/with-shorthand-export/expected.json
@@ -23,7 +23,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
-            "type": "Func",
+            "exportType": "Func",
             "id": {
               "type": "Identifier",
               "value": "func_0"
@@ -50,7 +50,7 @@
           "type": "ModuleExport",
           "name": "b",
           "descr": {
-            "type": "Func",
+            "exportType": "Func",
             "id": {
               "type": "Identifier",
               "value": "func_1"
@@ -79,7 +79,7 @@
           "type": "ModuleExport",
           "name": "c",
           "descr": {
-            "type": "Func",
+            "exportType": "Func",
             "id": {
               "type": "Identifier",
               "value": "func_2"

--- a/packages/wast-parser/test/fixtures/func/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/func/with-shorthand-export/expected.json
@@ -23,6 +23,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Func",
             "id": {
               "type": "Identifier",
@@ -50,6 +51,7 @@
           "type": "ModuleExport",
           "name": "b",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Func",
             "id": {
               "type": "Identifier",
@@ -79,6 +81,7 @@
           "type": "ModuleExport",
           "name": "c",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Func",
             "id": {
               "type": "Identifier",

--- a/packages/wast-parser/test/fixtures/global/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/global/with-shorthand-export/expected.json
@@ -45,7 +45,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
-            "type": "Global",
+            "exportType": "Global",
             "id": {
               "type": "Identifier",
               "value": "test"
@@ -93,7 +93,7 @@
           "type": "ModuleExport",
           "name": "b",
           "descr": {
-            "type": "Global",
+            "exportType": "Global",
             "id": {
               "type": "Identifier",
               "value": "global_1",
@@ -142,7 +142,7 @@
           "type": "ModuleExport",
           "name": "c",
           "descr": {
-            "type": "Global",
+            "exportType": "Global",
             "id": {
               "type": "Identifier",
               "value": "global_2",

--- a/packages/wast-parser/test/fixtures/global/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/global/with-shorthand-export/expected.json
@@ -45,6 +45,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Global",
             "id": {
               "type": "Identifier",
@@ -93,6 +94,7 @@
           "type": "ModuleExport",
           "name": "b",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Global",
             "id": {
               "type": "Identifier",
@@ -142,6 +144,7 @@
           "type": "ModuleExport",
           "name": "c",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Global",
             "id": {
               "type": "Identifier",

--- a/packages/wast-parser/test/fixtures/memory/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/memory/with-shorthand-export/expected.json
@@ -21,7 +21,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
-            "type": "Memory",
+            "exportType": "Memory",
             "id": {
               "type": "Identifier",
               "value": "memory_0",

--- a/packages/wast-parser/test/fixtures/memory/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/memory/with-shorthand-export/expected.json
@@ -21,6 +21,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Memory",
             "id": {
               "type": "Identifier",

--- a/packages/wast-parser/test/fixtures/module/anonymous-module-with-export/expected.json
+++ b/packages/wast-parser/test/fixtures/module/anonymous-module-with-export/expected.json
@@ -9,7 +9,7 @@
           "type": "ModuleExport",
           "name": "add",
           "descr": {
-            "type": "Func",
+            "exportType": "Func",
             "id": {
               "type": "Identifier",
               "value": "add"

--- a/packages/wast-parser/test/fixtures/module/anonymous-module-with-export/expected.json
+++ b/packages/wast-parser/test/fixtures/module/anonymous-module-with-export/expected.json
@@ -9,6 +9,7 @@
           "type": "ModuleExport",
           "name": "add",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Func",
             "id": {
               "type": "Identifier",

--- a/packages/wast-parser/test/fixtures/nan/function-argument/expected.json
+++ b/packages/wast-parser/test/fixtures/nan/function-argument/expected.json
@@ -109,7 +109,7 @@
           "type": "ModuleExport",
           "name": "reinterpret_f32_i32",
           "descr": {
-            "type": "Func",
+            "exportType": "Func",
             "id": {
               "type": "Identifier",
               "value": "reinterpret_f32_i32"

--- a/packages/wast-parser/test/fixtures/nan/function-argument/expected.json
+++ b/packages/wast-parser/test/fixtures/nan/function-argument/expected.json
@@ -109,6 +109,7 @@
           "type": "ModuleExport",
           "name": "reinterpret_f32_i32",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Func",
             "id": {
               "type": "Identifier",

--- a/packages/wast-parser/test/fixtures/table/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/table/with-shorthand-export/expected.json
@@ -22,6 +22,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
+            "type": "ModuleExportDescr",
             "exportType": "Table",
             "id": {
               "type": "Identifier",

--- a/packages/wast-parser/test/fixtures/table/with-shorthand-export/expected.json
+++ b/packages/wast-parser/test/fixtures/table/with-shorthand-export/expected.json
@@ -22,7 +22,7 @@
           "type": "ModuleExport",
           "name": "a",
           "descr": {
-            "type": "Table",
+            "exportType": "Table",
             "id": {
               "type": "Identifier",
               "value": "table_0",

--- a/packages/wast-printer/src/index.js
+++ b/packages/wast-printer/src/index.js
@@ -870,7 +870,7 @@ function printModuleExport(n: ModuleExport): string {
   out += space;
   out += quote(n.name);
 
-  if (n.descr.type === "Func") {
+  if (n.descr.exportType === "Func") {
     out += space;
     out += "(";
     out += "func";

--- a/packages/webassemblyjs/src/compiler/compile/module.js
+++ b/packages/webassemblyjs/src/compiler/compile/module.js
@@ -44,7 +44,7 @@ export function createCompiledModule(ast: Program): CompiledModule {
 
   t.traverse(ast, {
     ModuleExport({ node }: NodePath<ModuleExport>) {
-      if (node.descr.type === "Func") {
+      if (node.descr.exportType === "Func") {
         exports.push({
           name: node.name,
           kind: "function"

--- a/packages/webassemblyjs/src/interpreter/runtime/values/module.js
+++ b/packages/webassemblyjs/src/interpreter/runtime/values/module.js
@@ -305,7 +305,7 @@ function instantiateExports(
       moduleInstance.exports.push({
         name: node.name,
         value: {
-          type: node.descr.type,
+          type: node.descr.exportType,
           addr: instantiatedItem.addr
         }
       });
@@ -318,7 +318,7 @@ function instantiateExports(
 
   traverse(n, {
     ModuleExport({ node }: NodePath<ModuleExport>) {
-      switch (node.descr.type) {
+      switch (node.descr.exportType) {
         case "Func": {
           createModuleExport(
             node,

--- a/packages/webassemblyjs/test/fixtures/call-func-with-i64-arg/exec.tjs
+++ b/packages/webassemblyjs/test/fixtures/call-func-with-i64-arg/exec.tjs
@@ -1,7 +1,6 @@
 it("should throw when calling the exported function", () => {
   const m = WebAssembly.instantiateFromSource(watmodule);
 
-  debugger;
   const fn = m.exports.test;
 
   assert.throws(fn, "i64 in signature");

--- a/packages/webassemblyjs/test/fixtures/call-func-with-i64-arg/exec.tjs
+++ b/packages/webassemblyjs/test/fixtures/call-func-with-i64-arg/exec.tjs
@@ -1,6 +1,7 @@
 it("should throw when calling the exported function", () => {
   const m = WebAssembly.instantiateFromSource(watmodule);
 
+  debugger;
   const fn = m.exports.test;
 
   assert.throws(fn, "i64 in signature");

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,8 @@ cd $ROOT_DIR
 
 OPTS="$@"
 
+npm run build-fuzzer --prefix ./packages/floating-point-hex-parser
+
 for D in ./packages/*; do
   if [ ! -d "${D}/src" ]; then
     continue

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,14 +7,6 @@ set -e
 PACKAGES="./packages/*"
 
 
-## Launch pretest scripts if provided
-# for D in ./packages/*; do
-#     (npm run pretest --silent --prefix $D || true) &
-#     echo "launch pretest target for $D ..."
-# done
-
-wait
-
 ./node_modules/.bin/mocha "$PACKAGES/test/**/*.js" \
     --recursive \
     --reporter=tap \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,10 +8,10 @@ PACKAGES="./packages/*"
 
 
 ## Launch pretest scripts if provided
-for D in ./packages/*; do
-    (npm run pretest --silent --prefix $D || true) &
-    echo "launch pretest target for $D ..."
-done
+# for D in ./packages/*; do
+#     (npm run pretest --silent --prefix $D || true) &
+#     echo "launch pretest target for $D ..."
+# done
 
 wait
 

--- a/types/AST.js
+++ b/types/AST.js
@@ -63,7 +63,6 @@ type Signature = {
 type SignatureOrTypeRef = Index | Signature;
 
 type Valtype = "i32" | "i64" | "f32" | "f64" | "u32" | "label";
-type ExportDescr = "Func" | "Table" | "Memory" | "Global";
 type Mutability = "const" | "var";
 type InstructionType = "Instr" | ControlInstruction;
 type ControlInstruction =
@@ -389,15 +388,22 @@ type CallIndirectInstruction = {
   index?: Index
 };
 
+type ExportDescrType = "Func" | "Table" | "Memory" | "Global";
+
+type ExportDescr = {
+  ...BaseNode,
+
+  type: "ModuleExportDescr",
+  exportType: ExportDescrType,
+  id: Index
+};
+
 type ModuleExport = {
   ...BaseNode,
 
   type: "ModuleExport",
   name: string,
-  descr: {
-    exportType: ExportDescr,
-    id: Index
-  }
+  descr: ExportDescr
 };
 
 type Limit = {

--- a/types/AST.js
+++ b/types/AST.js
@@ -395,7 +395,7 @@ type ModuleExport = {
   type: "ModuleExport",
   name: string,
   descr: {
-    type: ExportDescr,
+    exportType: ExportDescr,
     id: Index
   }
 };


### PR DESCRIPTION
fixes #263 

This was surprisingly straightforward, the traverse function is now only around 10 lines of code. Basically it recurses the AST invoking the callback on any object that has a `type` property.

The only issue was the module exports, currently they have an AST representation that is a little misleading, e.g. a function export is as follows:

```
{
  "type": "ModuleExport",
  "name": "add",
  "descr": {
    "type": "Func",
    "id": {
      "type": "Identifier",
      "value": "func_0"
    }
  }
}
```

The above looks like a `Func` node, when it isn't.

I've modified the AST to ass a `ModuleExportDesc` node type:

```
{
  "type": "ModuleExport",
  "name": "add",
  "descr": {
    "type": "ModuleExportDescr",  <---- new type
    "exportType": "Func",                <---- describes the type being referenced
    "id": {
      "type": "Identifier",
      "value": "func_0"
    }
  }
}
```

TODO:
 - [x] fix the one failing unit test
 - [x] add a bit of documentation about how traverse works