### PR TITLE
Re-enable module name decoding test

### DIFF
--- a/packages/wasm-parser/test/fixtures/module/name/actual.wat-failure
+++ b/packages/wasm-parser/test/fixtures/module/name/actual.wat-failure
@@ -1,2 +1,0 @@
-;; binaryen doesn't include it
-(module $a)


### PR DESCRIPTION
Wabt added the support https://github.com/WebAssembly/wabt/pull/831. We need to wait that wabt.js publishes a new version.