### PR TITLE
fix: removed unnecessary cross-project dependencies

### DIFF
--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -15,8 +15,7 @@
     "@webassemblyjs/helper-wasm-bytecode": "1.5.4",
     "@webassemblyjs/wast-parser": "1.5.4",
     "debug": "^3.1.0",
-    "mamacro": "^0.0.3",
-    "webassemblyjs": "1.5.4"
+    "mamacro": "^0.0.3"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,8 +21,7 @@
     "@webassemblyjs/ast": "1.5.4",
     "@webassemblyjs/wasm-parser": "1.5.4",
     "@webassemblyjs/wast-parser": "1.5.4",
-    "@webassemblyjs/wast-printer": "1.5.4",
-    "webassemblyjs": "1.5.4"
+    "@webassemblyjs/wast-printer": "1.5.4"
   },
   "bin": {
     "wasmdump": "lib/wasmdump.js",

--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -19,8 +19,7 @@
     "@webassemblyjs/ast": "1.5.4",
     "@webassemblyjs/helper-wasm-bytecode": "1.5.4",
     "@webassemblyjs/leb128": "1.5.4",
-    "@webassemblyjs/wasm-parser": "1.5.4",
-    "webassemblyjs": "1.5.4"
+    "@webassemblyjs/wasm-parser": "1.5.4"
   },
   "repository": {
     "type": "git",

--- a/packages/wasm-parser/src/decoder.js
+++ b/packages/wasm-parser/src/decoder.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { CompileError } from "webassemblyjs/lib/errors";
+import { CompileError } from "./errors";
 
 import {
   decodeInt32,

--- a/packages/wasm-parser/src/errors.js
+++ b/packages/wasm-parser/src/errors.js
@@ -1,0 +1,3 @@
+// @flow
+
+export class CompileError extends Error {}

--- a/packages/wast-parser/package.json
+++ b/packages/wast-parser/package.json
@@ -22,8 +22,7 @@
     "@webassemblyjs/helper-code-frame": "1.5.4",
     "@webassemblyjs/helper-fsm": "1.5.4",
     "long": "^3.2.0",
-    "mamacro": "^0.0.3",
-    "webassemblyjs": "1.5.4"
+    "mamacro": "^0.0.3"
   },
   "devDependencies": {
     "@webassemblyjs/helper-test-framework": "1.5.4"

--- a/packages/wast-parser/src/errors.js
+++ b/packages/wast-parser/src/errors.js
@@ -1,0 +1,3 @@
+// @flow
+
+export class CompileError extends Error {}

--- a/packages/wast-parser/src/number-literals.js
+++ b/packages/wast-parser/src/number-literals.js
@@ -1,7 +1,7 @@
 // @flow
 const Long = require("long");
 const parseHexFloat = require("@webassemblyjs/floating-point-hex-parser");
-const { CompileError } = require("webassemblyjs/lib/errors");
+const { CompileError } = require("./errors");
 
 export function parse32F(sourceString: string): number {
   if (isHexLiteral(sourceString)) {


### PR DESCRIPTION
fixes #325 

I spotted this when adding the @webassembly/ast to astexplorer - it basically drags in everything via the dependency on `webassemblyjs`. This change removes these dependencies.

However ... a few projects depend on `webassemblyjs` just for `CompileError`. I've gone for the simple option, and created project-specific errors. I don't think reference equality of error constructors is that important?