### PR TITLE
fix: wasm parser adds generated identifiers to globals

### DIFF
--- a/packages/wasm-parser/src/decoder.js
+++ b/packages/wasm-parser/src/decoder.js
@@ -1202,7 +1202,12 @@ export function decode(ab: ArrayBuffer, opts: DecoderOpts): Program {
 
       const endLoc = getPosition();
 
-      const node = t.withLoc(t.global(globalType, init), endLoc, startLoc);
+      const name = t.identifier(getUniqueName("global"));
+      const node = t.withLoc(
+        t.global(globalType, init, name),
+        endLoc,
+        startLoc
+      );
 
       globals.push(node);
       state.globalsInModule.push(node);

--- a/packages/wasm-parser/test/fixtures/data/constant-offset/actual.wat
+++ b/packages/wasm-parser/test/fixtures/data/constant-offset/actual.wat
@@ -1,0 +1,3 @@
+(module
+  (data (i32.const 25) "abc")
+)

--- a/packages/wasm-parser/test/fixtures/data/global-offset/actual.wat
+++ b/packages/wasm-parser/test/fixtures/data/global-offset/actual.wat
@@ -1,0 +1,4 @@
+(module
+  (global i32 (i32.const 1))
+  (data (get_global 0) "abc")
+)

--- a/packages/wasm-parser/test/fixtures/data/with-memory-index/actual.wast
+++ b/packages/wasm-parser/test/fixtures/data/with-memory-index/actual.wast
@@ -1,0 +1,1 @@
+(data 23 (i32.const 25) "abc")


### PR DESCRIPTION
Continuing to expand the wasm-parser tests when I have a few moments spare ...