### PR TITLE
Proper dependency declarations

### DIFF
--- a/packages/helper-module-context/package.json
+++ b/packages/helper-module-context/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/xtuc/webassemblyjs.git"
   },
   "dependencies": {
+    "debug": "^3.1.0",
     "mamacro": "^0.0.3"
   },
   "devDependencies": {

--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -21,6 +21,7 @@
     "@webassemblyjs/helper-wasm-bytecode": "1.5.11",
     "@webassemblyjs/ieee754": "1.5.11",
     "@webassemblyjs/leb128": "1.5.11",
+    "@webassemblyjs/utf8": "1.5.11",
     "@webassemblyjs/wasm-parser": "1.5.11"
   },
   "repository": {
@@ -34,7 +35,6 @@
     "@webassemblyjs/helper-buffer": "1.5.11",
     "@webassemblyjs/helper-test-framework": "1.5.11",
     "@webassemblyjs/helper-wasm-bytecode": "1.5.11",
-    "@webassemblyjs/utf8": "1.5.11",
     "@webassemblyjs/wasm-gen": "1.5.11",
     "@webassemblyjs/wast-parser": "1.5.11",
     "wabt": "^1.0.0"

--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -21,8 +21,7 @@
     "@webassemblyjs/helper-wasm-bytecode": "1.5.11",
     "@webassemblyjs/ieee754": "1.5.11",
     "@webassemblyjs/leb128": "1.5.11",
-    "@webassemblyjs/utf8": "1.5.11",
-    "@webassemblyjs/wasm-parser": "1.5.11"
+    "@webassemblyjs/utf8": "1.5.11"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
These improper dependency declarations cause these packages to fail when using a more strict client such as [pnpm](https://pnpm.js.org/).