### PR TITLE
correct remainingBytes calculation

### DIFF
--- a/packages/wasm-parser/src/decoder.js
+++ b/packages/wasm-parser/src/decoder.js
@@ -1708,8 +1708,8 @@ export function decode(ab: ArrayBuffer, opts: DecoderOpts): Program {
 
         if (opts.ignoreDataSection === true) {
           const remainingBytes =
-            // $FlowIgnore
-            sectionSizeInBytes - numberOfElements.nextIndex;
+            sectionSizeInBytes - numberOfElementsu32.nextIndex;
+
           eatBytes(remainingBytes); // eat the entire section
 
           dumpSep("ignore data (" + sectionSizeInBytes + " bytes)");

--- a/packages/wasm-parser/test/index.js
+++ b/packages/wasm-parser/test/index.js
@@ -83,15 +83,15 @@ describe("Binary decoder", () => {
 
   describe("ignore section(s)", () => {
     const decoderOpts = {
-      ignoreDataSection: true,
-    }
+      ignoreDataSection: true
+    };
 
     it("should eat the data section without overflowing", () => {
       const buffer = makeBuffer(
         encodeHeader(),
         encodeVersion(1),
         [constants.sections.data, 0x05, 0x01, 0x01, 0x41, 0x01, 0x00],
-        [constants.sections.custom, 0x04, 0x01, 0x01, 97, 0x00],
+        [constants.sections.custom, 0x04, 0x01, 0x01, 97, 0x00]
       );
 
       const ast = decode(buffer, decoderOpts);
@@ -99,7 +99,7 @@ describe("Binary decoder", () => {
       let foundCustomSection = false;
 
       traverse(ast, {
-        SectionMetadata({node}) {
+        SectionMetadata({ node }) {
           if (node.section === "custom") {
             foundCustomSection = true;
           }

--- a/packages/wasm-parser/test/index.js
+++ b/packages/wasm-parser/test/index.js
@@ -80,4 +80,33 @@ describe("Binary decoder", () => {
       assert.throws(fn, "Unexpected section: 0x3");
     });
   });
+
+  describe("ignore section(s)", () => {
+    const decoderOpts = {
+      ignoreDataSection: true,
+    }
+
+    it("should eat the data section without overflowing", () => {
+      const buffer = makeBuffer(
+        encodeHeader(),
+        encodeVersion(1),
+        [constants.sections.data, 0x05, 0x01, 0x01, 0x41, 0x01, 0x00],
+        [constants.sections.custom, 0x04, 0x01, 0x01, 97, 0x00],
+      );
+
+      const ast = decode(buffer, decoderOpts);
+
+      let foundCustomSection = false;
+
+      traverse(ast, {
+        SectionMetadata({node}) {
+          if (node.section === "custom") {
+            foundCustomSection = true;
+          }
+        }
+      });
+
+      assert.isTrue(foundCustomSection, "Custom section was not detected");
+    });
+  });
 });


### PR DESCRIPTION
Ref #414 

You can blame me, removing the FlowIgnore throws: ` Cannot get numberOfElements.nextIndex because property nextIndex is missing in Number`.