### PR TITLE
Ignore custom section decoding errors

### DIFF
--- a/packages/wasm-parser/test/index.js
+++ b/packages/wasm-parser/test/index.js
@@ -109,4 +109,19 @@ describe("Binary decoder", () => {
       assert.isTrue(foundCustomSection, "Custom section was not detected");
     });
   });
+
+  describe("custom section", () => {
+    it("should catch decoding errors", () => {
+      const buffer = makeBuffer(encodeHeader(), encodeVersion(1), [
+        constants.sections.custom,
+        0x04,
+        0x01,
+        /* Invalid name length */ 0x99,
+        97,
+        0x00
+      ]);
+
+      assert.isOk(decode(buffer));
+    });
+  });
 });


### PR DESCRIPTION
Spec: https://webassembly.github.io/spec/core/binary/modules.html#custom-section
> If an implementation interprets the contents of a custom section, then errors in that contents, or the placement of the section, must not invalidate the module.

@TimHambourger's test suite passes now, but it shows a lot of custom section decoding errors (`invalid UTF-8 encoding`).

The spec only mentions the content of the section, we need to figure out why the name is failing.