### PR TITLE
Fix decoding types name section

### DIFF
--- a/packages/leb128/src/index.js
+++ b/packages/leb128/src/index.js
@@ -3,13 +3,13 @@
 import leb from "./leb";
 
 /**
- * According to https://webassembly.github.io/spec/binary/values.html#binary-int
+ * According to https://webassembly.github.io/spec/core/binary/values.html#binary-int
  * max = ceil(32/7)
  */
 export const MAX_NUMBER_OF_BYTE_U32 = 5;
 
 /**
- * According to https://webassembly.github.io/spec/binary/values.html#binary-int
+ * According to https://webassembly.github.io/spec/core/binary/values.html#binary-int
  * max = ceil(64/7)
  */
 export const MAX_NUMBER_OF_BYTE_U64 = 10;

--- a/packages/wasm-parser/src/decoder.js
+++ b/packages/wasm-parser/src/decoder.js
@@ -1180,21 +1180,29 @@ export function decode(ab: ArrayBuffer, opts: DecoderOpts): Program {
     while (offset - initialOffset < remainingBytes) {
       // name_type
       const sectionTypeByte = readVaruint7();
-      eatBytes(1);
+      eatBytes(sectionTypeByte.nextIndex);
 
       // name_payload_len
       const subSectionSizeInBytesu32 = readVaruint32();
       eatBytes(subSectionSizeInBytesu32.nextIndex);
 
-      if (sectionTypeByte === 0) {
-        nameMetadata.push(...parseNameModule());
-      } else if (sectionTypeByte === 1) {
-        nameMetadata.push(...parseNameSectionFunctions());
-      } else if (sectionTypeByte === 2) {
-        nameMetadata.push(...parseNameSectionLocals());
-      } else {
-        // skip unknown subsection
-        eatBytes(subSectionSizeInBytesu32.value);
+      switch (sectionTypeByte.value) {
+        case 0: {
+          nameMetadata.push(...parseNameModule());
+          break;
+        }
+        case 1: {
+          nameMetadata.push(...parseNameSectionFunctions());
+          break;
+        }
+        case 2: {
+          nameMetadata.push(...parseNameSectionLocals());
+          break;
+        }
+        default: {
+          // skip unknown subsection
+          eatBytes(subSectionSizeInBytesu32.value);
+        }
       }
     }
 

--- a/packages/wasm-parser/src/index.js
+++ b/packages/wasm-parser/src/index.js
@@ -130,7 +130,14 @@ function restoreModuleName(ast) {
       // update module
       t.traverse(ast, {
         Module({ node }: NodePath<Module>) {
-          node.id = moduleNameMetadataPath.node.value;
+          let name = moduleNameMetadataPath.node.value;
+
+          // compatiblity with wast-parser
+          if (name === "") {
+            name = null;
+          }
+
+          node.id = name;
         }
       });
     }

--- a/packages/wasm-parser/test/index.js
+++ b/packages/wasm-parser/test/index.js
@@ -91,7 +91,7 @@ describe("Binary decoder", () => {
         encodeHeader(),
         encodeVersion(1),
         [constants.sections.data, 0x05, 0x01, 0x01, 0x41, 0x01, 0x00],
-        [constants.sections.custom, 0x04, 0x01, 0x01, 97, 0x00]
+        [constants.sections.custom, 0x04, 0x01, 0x01, 97, 0x00, 0x00]
       );
 
       const ast = decode(buffer, decoderOpts);


### PR DESCRIPTION
Basically:
- `name_payload_len` field was missing in module name (don't think we noticed it, we can't even test it because of missing feature upstream).
- `varuint7` instead of readByte (we need to use LEB128 to decode it (0xxxxxxx) otherwise the first bit would end up in the actual value)
- `varuint32` (doesn't really matter since it's variable, but now it's limited to 4 bytes)

cc @ColinEberhardt since it was quite interesting.

Ref https://github.com/xtuc/webassemblyjs/issues/414