### PR TITLE
wasm-text-gen: correct bin path

### DIFF
--- a/packages/wasm-text-gen/package.json
+++ b/packages/wasm-text-gen/package.json
@@ -24,7 +24,7 @@
   "author": "Sven Sauleau",
   "license": "MIT",
   "bin": {
-    "wasmgen": "src/cli.js"
+    "wasmgen": "lib/cli.js"
   },
   "dependencies": {
     "@babel/generator": "^7.0.0-beta.40",


### PR DESCRIPTION
Closes https://github.com/xtuc/webassemblyjs/issues/440