### PR TITLE
Handle export type "Mem"

### DIFF
--- a/packages/wast-printer/src/index.js
+++ b/packages/wast-printer/src/index.js
@@ -910,7 +910,7 @@ function printModuleExport(n: ModuleExport): string {
     out += printIndex(n.descr.id);
 
     out += ")";
-  } else if (n.descr.exportType === "Memory") {
+  } else if (n.descr.exportType === "Memory" || n.descr.exportType === "Mem") {
     out += space;
 
     out += "(";


### PR DESCRIPTION
Trying to decode with `wasm-parser` and then printing using `wast-printer` results in: 

```
.../webassemblyjs/packages/wast-printer/lib/index.js:849
    throw new Error("printModuleExport: unknown type: " + n.descr.exportType);
          ^
Error: printModuleExport: unknown type: Mem
    at printModuleExport (.../webassemblyjs/packages/wast-printer/lib/index.js:849:11)
    at .../webassemblyjs/packages/wast-printer/lib/index.js:148:18
    at Array.forEach (<anonymous>)
    at printModule (.../webassemblyjs/packages/wast-printer/lib/index.js:116:12)
    at .../webassemblyjs/packages/wast-printer/lib/index.js:43:14
    at Array.reduce (<anonymous>)
    at printProgram (.../webassemblyjs/packages/wast-printer/lib/index.js:41:17)
    at Object.print (.../webassemblyjs/packages/wast-printer/lib/index.js:34:12)
    at instrument (.../zeus-compute/src/metering/index.ts:18:16)
    at Object.<anonymous> (.../zeus-compute/src/metering/index.ts:21:1)
```

The `wasm-parser` should probably generate `exportType` with `"Memory"` instead of (accidentally?) `"Mem"`