### PR TITLE
Better readability for `make bootstrap`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean-all:
 	rm -rf ./node_modules ./packages/*/node_modules ./packages/*/{lib,esm}
 
 bootstrap: clean-all
-	yarn install
+	$(LERNA) bootstrap
 
 build:
 	WITH_TRACE=$(TRACE) ./scripts/build.sh


### PR DESCRIPTION
Basically, `lerna boostrap` with the configuration you have is the same as `yarn install`. But I made this change for better understanding of the Makefile for future contributors.