### PR TITLE
chore: fix sort to work on new node version

### DIFF
--- a/packages/ast/src/utils.js
+++ b/packages/ast/src/utils.js
@@ -57,7 +57,7 @@ export function sortSectionMetadata(m: Module) {
       throw new Error("Section id not found");
     }
 
-    return aId > bId;
+    return aId - bId;
   });
 }
 

--- a/packages/wasm-edit/src/index.js
+++ b/packages/wasm-edit/src/index.js
@@ -31,7 +31,7 @@ function sortBySectionOrder(nodes: Array<Node>) {
     }
 
     // $FlowIgnore ensured above
-    return aId > bId;
+    return aId - bId;
   });
 }
 

--- a/packages/wasm-edit/src/index.js
+++ b/packages/wasm-edit/src/index.js
@@ -30,7 +30,6 @@ function sortBySectionOrder(nodes: Array<Node>) {
       throw new Error("Section id not found");
     }
 
-    // $FlowIgnore ensured above
     return aId - bId;
   });
 }


### PR DESCRIPTION
This fixes the sorting problem w.r.t node-nightly builds

r? @xtuc 