### PR TITLE
fix helper-module-context dependencies

### DIFF
--- a/packages/helper-module-context/package.json
+++ b/packages/helper-module-context/package.json
@@ -11,9 +11,12 @@
     "type": "git",
     "url": "https://github.com/xtuc/webassemblyjs.git"
   },
-  "devDependencies": {
-    "@webassemblyjs/wast-parser": "1.8.2",
+  "dependencies": {
+    "@webassemblyjs/ast": "1.8.2",
     "mamacro": "^0.0.3"
+  },
+  "devDependencies": {
+    "@webassemblyjs/wast-parser": "1.8.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
fixing this issue: https://github.com/xtuc/webassemblyjs/issues/487

using pnpm, which does package isolation enforcing proper dependencies

with the latest @webassemblyjs packages (indirectly getting them with the webpack 4.29.4 update), getting this error
Error: Cannot find module '@webassemblyjs/ast' from helper-module-context