### PR TITLE
move mamacro to dev-dependencies in helper-compiler and helper-module…

### DIFF
--- a/packages/helper-compiler/package.json
+++ b/packages/helper-compiler/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@webassemblyjs/ast": "1.8.5",
-    "@webassemblyjs/helper-flatten-ast": "1.8.5",
-    "mamacro": "^0.0.7"
+    "@webassemblyjs/helper-flatten-ast": "1.8.5"
   },
   "devDependencies": {
     "@webassemblyjs/helper-test-framework": "1.8.5",
     "@webassemblyjs/wasm-parser": "1.8.5",
+    "mamacro": "0.0.7",
     "wabt": "1.0.0-nightly.20180421"
   },
   "publishConfig": {

--- a/packages/helper-module-context/package.json
+++ b/packages/helper-module-context/package.json
@@ -12,11 +12,11 @@
     "url": "https://github.com/xtuc/webassemblyjs.git"
   },
   "dependencies": {
-    "@webassemblyjs/ast": "1.8.5",
-    "mamacro": "^0.0.7"
+    "@webassemblyjs/ast": "1.8.5"
   },
   "devDependencies": {
-    "@webassemblyjs/wast-parser": "1.8.5"
+    "@webassemblyjs/wast-parser": "1.8.5",
+    "mamacro": "^0.0.7"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
mamacro should be a devDepenceny as outlined by @xtuc in https://github.com/xtuc/mamacro/issues/2.

Resolves #578 