### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/packages/helper-api-error/package.json
+++ b/packages/helper-api-error/package.json
@@ -6,6 +6,11 @@
   "module": "esm/index.js",
   "author": "Sven Sauleau",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xtuc/webassemblyjs.git",
+    "directory": "packages/helper-api-error"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	*@webassemblyjs/helper-api-error