### PR TITLE
wasm-parser: skip rather than throw on unknown sections

### DIFF
--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webassemblyjs/wasm-parser",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "keywords": [
     "webassembly",
     "javascript",

--- a/packages/wasm-parser/src/decoder.js
+++ b/packages/wasm-parser/src/decoder.js
@@ -1872,7 +1872,20 @@ export function decode(ab: ArrayBuffer, opts: DecoderOpts): Program {
       }
     }
 
-    throw new CompileError("Unexpected section: " + toHex(sectionId));
+    if (opts.errorOnUnknownSection) {
+      throw new CompileError("Unexpected section: " + toHex(sectionId));
+    } else {
+      dumpSep("section " + toHex(sectionId));
+      dump([sectionId], "section code");
+      dump([sectionSizeInBytes], "section size");
+      eatBytes(sectionSizeInBytes);
+      dumpSep("ignoring (" + sectionSizeInBytes + " bytes)");
+      return {
+        nodes: [],
+        metadata: [],
+        nextSectionIndex: 0,
+      };
+    }
   }
 
   parseModuleHeader();

--- a/packages/wasm-parser/src/types/decoder.js
+++ b/packages/wasm-parser/src/types/decoder.js
@@ -85,4 +85,5 @@ type DecoderOpts = {
   ignoreDataSection: boolean,
   ignoreCodeSection: boolean,
   ignoreCustomNameSection: boolean,
+  errorOnUnknownSection: boolean,
 };


### PR DESCRIPTION
One new section type is 0xd `exception`, which doesn't need any special processing, and the details aren't useful to e.g. Webpack.  It seems most robust to just skip unknown sections by default rather than have to make a change + release to unbreak parsing for spec additions.

I also added an option `errorOnUnknownSection` to keep the old behavior, in case people want to match the old behavior.

I tested this by patching a local project that uses the new exception instructions (`throw`, `try`, etc) in a WebAssembly file that is processed by Webpack and it works well.

Finally I bumped the version for `wasm-parser`.  If this looks good + mergable (happy to make changes, too!), @xtuc could you cut a release?