### PR TITLE
upgrade the dependencies version in the ast package to 1.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "engines": {
-    "yarn": "^1.5.0"
+    "yarn": "^1.5.0",
+    "node": "^14.15.0 || >=16.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.15.4",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -12,8 +12,8 @@
   "author": "Sven Sauleau",
   "license": "MIT",
   "dependencies": {
-    "@webassemblyjs/helper-numbers": "1.11.3",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.3"
+    "@webassemblyjs/helper-numbers": "1.11.4",
+    "@webassemblyjs/helper-wasm-bytecode": "1.11.4"
   },
   "repository": {
     "type": "git",

--- a/packages/helper-wasm-section/package.json
+++ b/packages/helper-wasm-section/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@webassemblyjs/ast": "1.11.3",
     "@webassemblyjs/helper-buffer": "1.11.3",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.3",
+    "@webassemblyjs/helper-wasm-bytecode": "1.11.4",
     "@webassemblyjs/wasm-gen": "1.11.3"
   },
   "devDependencies": {

--- a/packages/wasm-edit/package.json
+++ b/packages/wasm-edit/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@webassemblyjs/ast": "1.11.3",
     "@webassemblyjs/helper-buffer": "1.11.3",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.3",
+    "@webassemblyjs/helper-wasm-bytecode": "1.11.4",
     "@webassemblyjs/helper-wasm-section": "1.11.3",
     "@webassemblyjs/wasm-gen": "1.11.3",
     "@webassemblyjs/wasm-opt": "1.11.3",

--- a/packages/wasm-gen/package.json
+++ b/packages/wasm-gen/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@webassemblyjs/ast": "1.11.3",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.3",
+    "@webassemblyjs/helper-wasm-bytecode": "1.11.4",
     "@webassemblyjs/ieee754": "1.11.3",
     "@webassemblyjs/leb128": "1.11.3",
     "@webassemblyjs/utf8": "1.11.3"

--- a/packages/wasm-gen/package.json
+++ b/packages/wasm-gen/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@webassemblyjs/ast": "1.11.3",
     "@webassemblyjs/helper-wasm-bytecode": "1.11.4",
-    "@webassemblyjs/ieee754": "1.11.3",
+    "@webassemblyjs/ieee754": "1.11.4",
     "@webassemblyjs/leb128": "1.11.3",
     "@webassemblyjs/utf8": "1.11.3"
   }

--- a/packages/wasm-gen/package.json
+++ b/packages/wasm-gen/package.json
@@ -20,7 +20,7 @@
     "@webassemblyjs/ast": "1.11.3",
     "@webassemblyjs/helper-wasm-bytecode": "1.11.4",
     "@webassemblyjs/ieee754": "1.11.4",
-    "@webassemblyjs/leb128": "1.11.3",
-    "@webassemblyjs/utf8": "1.11.3"
+    "@webassemblyjs/leb128": "1.11.4",
+    "@webassemblyjs/utf8": "1.11.4"
   }
 }

--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -20,7 +20,7 @@
     "@webassemblyjs/ast": "1.11.3",
     "@webassemblyjs/helper-api-error": "1.11.3",
     "@webassemblyjs/helper-wasm-bytecode": "1.11.4",
-    "@webassemblyjs/ieee754": "1.11.3",
+    "@webassemblyjs/ieee754": "1.11.4",
     "@webassemblyjs/leb128": "1.11.3",
     "@webassemblyjs/utf8": "1.11.3"
   },

--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@webassemblyjs/ast": "1.11.3",
-    "@webassemblyjs/helper-api-error": "1.11.3",
+    "@webassemblyjs/helper-api-error": "1.11.4",
     "@webassemblyjs/helper-wasm-bytecode": "1.11.4",
     "@webassemblyjs/ieee754": "1.11.4",
     "@webassemblyjs/leb128": "1.11.4",

--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@webassemblyjs/ast": "1.11.3",
     "@webassemblyjs/helper-api-error": "1.11.3",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.3",
+    "@webassemblyjs/helper-wasm-bytecode": "1.11.4",
     "@webassemblyjs/ieee754": "1.11.3",
     "@webassemblyjs/leb128": "1.11.3",
     "@webassemblyjs/utf8": "1.11.3"

--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -21,8 +21,8 @@
     "@webassemblyjs/helper-api-error": "1.11.3",
     "@webassemblyjs/helper-wasm-bytecode": "1.11.4",
     "@webassemblyjs/ieee754": "1.11.4",
-    "@webassemblyjs/leb128": "1.11.3",
-    "@webassemblyjs/utf8": "1.11.3"
+    "@webassemblyjs/leb128": "1.11.4",
+    "@webassemblyjs/utf8": "1.11.4"
   },
   "repository": {
     "type": "git",

--- a/packages/wast-parser/package.json
+++ b/packages/wast-parser/package.json
@@ -22,7 +22,7 @@
     "@webassemblyjs/floating-point-hex-parser": "1.11.4",
     "@webassemblyjs/helper-api-error": "1.11.4",
     "@webassemblyjs/helper-code-frame": "1.11.3",
-    "@webassemblyjs/helper-fsm": "1.11.3",
+    "@webassemblyjs/helper-fsm": "1.11.4",
     "@xtuc/long": "4.2.2"
   },
   "devDependencies": {

--- a/packages/wast-parser/package.json
+++ b/packages/wast-parser/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@webassemblyjs/ast": "1.11.3",
     "@webassemblyjs/floating-point-hex-parser": "1.11.3",
-    "@webassemblyjs/helper-api-error": "1.11.3",
+    "@webassemblyjs/helper-api-error": "1.11.4",
     "@webassemblyjs/helper-code-frame": "1.11.3",
     "@webassemblyjs/helper-fsm": "1.11.3",
     "@xtuc/long": "4.2.2"

--- a/packages/wast-parser/package.json
+++ b/packages/wast-parser/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@webassemblyjs/ast": "1.11.3",
-    "@webassemblyjs/floating-point-hex-parser": "1.11.3",
+    "@webassemblyjs/floating-point-hex-parser": "1.11.4",
     "@webassemblyjs/helper-api-error": "1.11.4",
     "@webassemblyjs/helper-code-frame": "1.11.3",
     "@webassemblyjs/helper-fsm": "1.11.3",

--- a/packages/webassemblyjs/package.json
+++ b/packages/webassemblyjs/package.json
@@ -27,7 +27,7 @@
     "@xtuc/long": "4.2.2"
   },
   "devDependencies": {
-    "@webassemblyjs/floating-point-hex-parser": "1.11.3",
+    "@webassemblyjs/floating-point-hex-parser": "1.11.4",
     "mamacro": "^0.0.7",
     "wabt": "1.0.0-nightly.20180421"
   },


### PR DESCRIPTION
Version 1.11.3 is no longer on NPM
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/53588889/193200327-96f40dc5-9ed1-46a2-9cdb-91fd075d48c3.png">
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/53588889/193200400-3f66be2b-c250-4995-b081-781e7600be5d.png">
<img width="1391" alt="image" src="https://user-images.githubusercontent.com/53588889/193202103-81858869-c365-4f98-aade-b4ada91536ab.png">
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/53588889/193202667-4bbca0c3-c737-4d6b-8060-1d9587660e1d.png">
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/53588889/193202578-3c2a1bc6-c79b-4b3e-b358-780174995192.png">


