### PR TITLE
Change utf8 decoder to be iterative and not overflow the call stack

### DIFF
--- a/packages/utf8/src/decoder.js
+++ b/packages/utf8/src/decoder.js
@@ -75,10 +75,12 @@ function _decode(bytes) {
       const [b1, b2, b3, b4, ...bs] = remainingBytes;
 
       if (b1 < 0xf8) {
-        acc.push(code(
-          0x10000,
-          ((((b1 & 0x07) << 18) + con(b2)) << 12) + (con(b3) << 6) + con(b4)
-        ));
+        acc.push(
+          code(
+            0x10000,
+            ((((b1 & 0x07) << 18) + con(b2)) << 12) + (con(b3) << 6) + con(b4)
+          )
+        );
         remainingBytes = bs;
         continue;
       }


### PR DESCRIPTION
I was getting errors similar to #918 and #922 (converting a rust lib to WASM) and noted that the stack was overflowing due to the recursion in the `_decode()` function of the `utf8` package.

Changing the implementation to be iterative resolved these errors for me.