### PR TITLE
chore: update `@webassemblyjs` dependencies to `1.12.1`

### DIFF
--- a/packages/wasm-gen/package.json
+++ b/packages/wasm-gen/package.json
@@ -18,10 +18,10 @@
   "license": "MIT",
   "dependencies": {
     "@webassemblyjs/ast": "1.12.1",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-    "@webassemblyjs/ieee754": "1.11.6",
-    "@webassemblyjs/leb128": "1.11.6",
-    "@webassemblyjs/utf8": "1.11.6"
+    "@webassemblyjs/helper-wasm-bytecode": "1.12.1",
+    "@webassemblyjs/ieee754": "1.12.1",
+    "@webassemblyjs/leb128": "1.12.1",
+    "@webassemblyjs/utf8": "1.12.1"
   },
   "gitHead": "6d1606bde5ab7ef21ea4b25715bd2fe58e8742cd"
 }

--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -18,11 +18,11 @@
   "license": "MIT",
   "dependencies": {
     "@webassemblyjs/ast": "1.12.1",
-    "@webassemblyjs/helper-api-error": "1.11.6",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-    "@webassemblyjs/ieee754": "1.11.6",
-    "@webassemblyjs/leb128": "1.11.6",
-    "@webassemblyjs/utf8": "1.11.6"
+    "@webassemblyjs/helper-api-error": "1.12.1",
+    "@webassemblyjs/helper-wasm-bytecode": "1.12.1",
+    "@webassemblyjs/ieee754": "1.12.1",
+    "@webassemblyjs/leb128": "1.12.1",
+    "@webassemblyjs/utf8": "1.12.1"
   },
   "repository": {
     "type": "git",

--- a/packages/wast-parser/package.json
+++ b/packages/wast-parser/package.json
@@ -19,10 +19,10 @@
   "license": "MIT",
   "dependencies": {
     "@webassemblyjs/ast": "1.12.1",
-    "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-    "@webassemblyjs/helper-api-error": "1.11.6",
+    "@webassemblyjs/floating-point-hex-parser": "1.12.1",
+    "@webassemblyjs/helper-api-error": "1.12.1",
     "@webassemblyjs/helper-code-frame": "1.12.1",
-    "@webassemblyjs/helper-fsm": "1.11.6",
+    "@webassemblyjs/helper-fsm": "1.12.1",
     "@xtuc/long": "4.2.2"
   },
   "devDependencies": {

--- a/packages/webassemblyjs/package.json
+++ b/packages/webassemblyjs/package.json
@@ -27,7 +27,7 @@
     "@xtuc/long": "4.2.2"
   },
   "devDependencies": {
-    "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+    "@webassemblyjs/floating-point-hex-parser": "1.12.1",
     "mamacro": "^0.0.7",
     "wabt": "1.0.0-nightly.20180421"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,6 +2157,30 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@webassemblyjs/floating-point-hex-parser@1.11.6":
+  version "1.11.6"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz#dacbcb95aff135c8260f77fa3b4c5fea600a6431"
+  integrity sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==
+
+"@webassemblyjs/helper-api-error@1.11.6":
+  version "1.11.6"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz#6132f68c4acd59dcd141c44b18cbebbd9f2fa768"
+  integrity sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==
+
+"@webassemblyjs/helper-numbers@1.11.6":
+  version "1.11.6"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz#cbce5e7e0c1bd32cf4905ae444ef64cea919f1b5"
+  integrity sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.6"
+    "@webassemblyjs/helper-api-error" "1.11.6"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.6":
+  version "1.11.6"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz#bb2ebdb3b83aa26d9baad4c46d4315283acd51e9"
+  integrity sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz"


### PR DESCRIPTION
Hi. I discovered this issue since `@webassemblyjs/wasm-parser` is using an older (pinned) dependency of `@webassemblyjs/leb128` using deprecated `new Buffer()`.

I made this PR that upgrades all pinned dependencies to 1.12.1. Tests pass but it might be an oversight and if it was intentional that they are kept with `1.11` please directly close it.

---

CI fails but I guess is unrelated:

<img width="917" alt="image" src="https://github.com/xtuc/webassemblyjs/assets/5158436/50a0da25-f62f-410c-bde8-634d8d8a1663">
