### PR TITLE
chore: bump up internal package versions to fix esm issue.

### DIFF
--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -12,8 +12,8 @@
   "author": "Sven Sauleau",
   "license": "MIT",
   "dependencies": {
-    "@webassemblyjs/helper-numbers": "1.11.6",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+    "@webassemblyjs/helper-numbers": "1.12.1",
+    "@webassemblyjs/helper-wasm-bytecode": "1.12.1"
   },
   "repository": {
     "type": "git",

--- a/packages/helper-wasm-section/package.json
+++ b/packages/helper-wasm-section/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@webassemblyjs/ast": "1.12.1",
     "@webassemblyjs/helper-buffer": "1.12.1",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+    "@webassemblyjs/helper-wasm-bytecode": "1.12.1",
     "@webassemblyjs/wasm-gen": "1.12.1"
   },
   "devDependencies": {

--- a/packages/wasm-edit/package.json
+++ b/packages/wasm-edit/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@webassemblyjs/ast": "1.12.1",
     "@webassemblyjs/helper-buffer": "1.12.1",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+    "@webassemblyjs/helper-wasm-bytecode": "1.12.1",
     "@webassemblyjs/helper-wasm-section": "1.12.1",
     "@webassemblyjs/wasm-gen": "1.12.1",
     "@webassemblyjs/wasm-opt": "1.12.1",

--- a/packages/wasm-gen/package.json
+++ b/packages/wasm-gen/package.json
@@ -18,10 +18,10 @@
   "license": "MIT",
   "dependencies": {
     "@webassemblyjs/ast": "1.12.1",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-    "@webassemblyjs/ieee754": "1.11.6",
-    "@webassemblyjs/leb128": "1.11.6",
-    "@webassemblyjs/utf8": "1.11.6"
+    "@webassemblyjs/helper-wasm-bytecode": "1.12.1",
+    "@webassemblyjs/ieee754": "1.12.1",
+    "@webassemblyjs/leb128": "1.12.1",
+    "@webassemblyjs/utf8": "1.12.1"
   },
   "gitHead": "6d1606bde5ab7ef21ea4b25715bd2fe58e8742cd"
 }

--- a/packages/wasm-parser/package.json
+++ b/packages/wasm-parser/package.json
@@ -18,11 +18,11 @@
   "license": "MIT",
   "dependencies": {
     "@webassemblyjs/ast": "1.12.1",
-    "@webassemblyjs/helper-api-error": "1.11.6",
-    "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-    "@webassemblyjs/ieee754": "1.11.6",
-    "@webassemblyjs/leb128": "1.11.6",
-    "@webassemblyjs/utf8": "1.11.6"
+    "@webassemblyjs/helper-api-error": "1.12.1",
+    "@webassemblyjs/helper-wasm-bytecode": "1.12.1",
+    "@webassemblyjs/ieee754": "1.12.1",
+    "@webassemblyjs/leb128": "1.12.1",
+    "@webassemblyjs/utf8": "1.12.1"
   },
   "repository": {
     "type": "git",

--- a/packages/wast-parser/package.json
+++ b/packages/wast-parser/package.json
@@ -19,10 +19,10 @@
   "license": "MIT",
   "dependencies": {
     "@webassemblyjs/ast": "1.12.1",
-    "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-    "@webassemblyjs/helper-api-error": "1.11.6",
+    "@webassemblyjs/floating-point-hex-parser": "1.12.1",
+    "@webassemblyjs/helper-api-error": "1.12.1",
     "@webassemblyjs/helper-code-frame": "1.12.1",
-    "@webassemblyjs/helper-fsm": "1.11.6",
+    "@webassemblyjs/helper-fsm": "1.12.1",
     "@xtuc/long": "4.2.2"
   },
   "devDependencies": {

--- a/packages/webassemblyjs/package.json
+++ b/packages/webassemblyjs/package.json
@@ -27,7 +27,7 @@
     "@xtuc/long": "4.2.2"
   },
   "devDependencies": {
-    "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+    "@webassemblyjs/floating-point-hex-parser": "1.12.1",
     "mamacro": "^0.0.7",
     "wabt": "1.0.0-nightly.20180421"
   },


### PR DESCRIPTION
Hi there, I'm working on a project that use a esm bundler. I found a module resolve issue related to this packages. Some of the internal packages version is out dated, and they are also not correctly build esm version ( the esm folder is missing in 1.11.6) 
This PR should fix this small issue. Please review and push out a minor release if you could (or just re-publish as same current version, whatever suit your release method). 
Thanks!